### PR TITLE
Fixes, as well as avoiding known issues with using timers in some context

### DIFF
--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -282,6 +282,7 @@ class MigrateBatchExecutable extends MigrateExecutable {
 
       try {
         $status = $this->processRowFromQueue($row);
+        ++$sandbox['current'];
         $context['message'] = $this->t('Migration "@migration": @current/@total; processed row with IDs: (@ids)', [
           '@migration' => $this->migration->id(),
           '@current'   => $sandbox['current'],


### PR DESCRIPTION
Alternative to #6

For the timer business... if we expect things to be reset, we can't use 'em in contexts that _won't_ reset them... like batches via drush, so let's just avoid 'em.