### PR TITLE
Adding auto code linting

### DIFF
--- a/.github/workflows/auto_lint.yml
+++ b/.github/workflows/auto_lint.yml
@@ -1,0 +1,18 @@
+name: Code Linting
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+
+      - name: Run CodeSniffer
+        uses: discoverygarden/CodeSniffer@v1.0.0
+        with:
+          path: ./


### PR DESCRIPTION
This will add the `Auto Code Linting` workflow to the DGI Migrate project.

This is being used as the pilot example of adding a Code Linting workflow to a project. It should also spin up an example of the Code Linting as reference.

Currently it will be failing as there are some phpcs warnings that were found on the repository.

Link to the applicable warnings:
https://github.com/nchiasson-dgi/dgi_migrate/pull/1/checks?check_run_id=3653842708

Also, in order for this workflow to be activated by pull requests from forks, an Admin level user will be required to enable the `Run workflows from fork pull requests` under `Fork pull request workflows` on the `settings/actions` page for the repository.