### PR TITLE
SER-98: Update setConfig to be agnostic of unset values

### DIFF
--- a/modules/dgi_migrate_edtf_validator/src/Plugin/migrate/process/Validator.php
+++ b/modules/dgi_migrate_edtf_validator/src/Plugin/migrate/process/Validator.php
@@ -60,7 +60,9 @@ class Validator extends ProcessPluginBase implements ConfigurableInterface {
    * {@inheritdoc}
    */
   public function setConfiguration(array $configuration) {
-    $this->configuration = $configuration + $this->defaultConfiguration();
+    foreach (['intervals', 'sets', 'strict'] as $key) {
+      $this->configuration[$key] = (!isset($configuration[$key]) ? $configuration[$key] : $this->defaultConfiguration()[$key]);
+    }
   }
 
   /**


### PR DESCRIPTION
Seems config values weren't actually being set, so the setConfiguration function wasn't actually working (since keys were set but not values, adding the two arrays did nothing to override with the default configuration). Nothing wrong with the validator itself 