### PR TITLE
FSU-44

### DIFF
--- a/config/install/migrate_plus.migration.foxml_nodes.yml
+++ b/config/install/migrate_plus.migration.foxml_nodes.yml
@@ -108,7 +108,7 @@ process:
   field_display_hints:
     - plugin: dgi_migrate.process.static_map
       source: '@_i8_model_uri'
-      bypass: true
+      default_value: []
       map:
         - ['https://schema.org/DigitalDocument', ['http://mozilla.github.io/pdf.js']]
         - ['http://purl.org/coar/resource_type/c_c513', ['http://openseadragon.github.io']]

--- a/modules/dgi_migrate_dspace/migrations/dgi_dspace_nodes.yml
+++ b/modules/dgi_migrate_dspace/migrations/dgi_dspace_nodes.yml
@@ -116,6 +116,9 @@ process:
       query: 'string(//mets:mdWrap[@MDTYPE="MODS"]/mets:xmlData//mods:titleInfo/mods:title)'
     - plugin: default_value
       default_value: Untitled
+    - plugin: substr
+      start: 0
+      length: 255
   field_handle:
     - << : *base_mods_node
       query: 'mods:identifier[@type="uri"]'
@@ -183,8 +186,8 @@ process:
       xpath: '@_mets_xpath'
       method: evaluate
       query: 'string(//mets:fileSec/mets:fileGrp[@USE="ORIGINAL"]/mets:file/@MIMETYPE)'
-    - plugin: skip_on_empty
-      method: process
+    - plugin: default_value
+      default_value: UNKNOWN
 
   # Basing the model off of the mimetype or Dspace type (COLLECTION, COMMUNITY,
   # OR ITEM).
@@ -196,10 +199,52 @@ process:
     - plugin: static_map
       bypass: false
       map:
-        'application/jpeg': 'http://purl.org/coar/resource_type/c_c513'
+        'audio/aac': 'http://purl.org/coar/resource_type/c_18cc'
+        'application/msword': 'https://schema.org/DigitalDocument'
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'https://schema.org/DigitalDocument'
+        'image/gif': 'http://purl.org/coar/resource_type/c_c513'
+        'image/jp2': 'http://purl.org/coar/resource_type/c_c513'
+        'image/jpeg': 'http://purl.org/coar/resource_type/c_c513'
+        'image/jpg': 'http://purl.org/coar/resource_type/c_c513'
+        'image/pjpeg': 'http://purl.org/coar/resource_type/c_c513'
+        'text/jpg': 'http://purl.org/coar/resource_type/c_c513'
+        'audio/mpeg': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/mpeg3': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/x-mpeg': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/x-mpeg-3': 'http://purl.org/coar/resource_type/c_18cc'
+        'video/x-mpeg': 'http://purl.org/coar/resource_type/c_18cc'
+        'video/mp4': 'http://purl.org/coar/resource_type/c_12ce'
         'application/pdf': 'https://schema.org/DigitalDocument'
+        'image/png': 'http://purl.org/coar/resource_type/c_c513'
+        'application/vnd.openxmlformats-officedocument.presentationml.slideshow': 'https://schema.org/DigitalDocument'
+        'application/mspowerpoint': 'https://schema.org/DigitalDocument'
+        'application/powerpoint': 'https://schema.org/DigitalDocument'
+        'application/vnd.ms-powerpoint': 'https://schema.org/DigitalDocument'
+        'application/x-mspowerpoint': 'https://schema.org/DigitalDocument'
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'https://schema.org/DigitalDocument'
+        'application/rtf': 'https://schema.org/DigitalDocument'
+        'application/x-rtf': 'https://schema.org/DigitalDocument'
+        'text/richtext': 'https://schema.org/DigitalDocument'
+        'image/tif': 'http://purl.org/coar/resource_type/c_c513'
+        'image/tiff': 'http://purl.org/coar/resource_type/c_c513'
+        'image/x-tiff': 'http://purl.org/coar/resource_type/c_c513'
+        'text/plain': 'https://schema.org/DigitalDocument'
+        'text/html': 'https://schema.org/DigitalDocument'
+        'audio/vnd.wave': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/wav': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/wave': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/x-wav': 'http://purl.org/coar/resource_type/c_18cc'
+        'audio/x-wave': 'http://purl.org/coar/resource_type/c_18cc'
+        'application/excel': 'https://schema.org/DigitalDocument'
+        'application/vnd.ms-excel': 'https://schema.org/DigitalDocument'
+        'application/x-excel': 'https://schema.org/DigitalDocument'
+        'application/x-msexcel': 'https://schema.org/DigitalDocument'
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'https://schema.org/DigitalDocument'
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.template': 'https://schema.org/DigitalDocument'
+        'application/vnd.ms-xpsdocument': 'https://schema.org/DigitalDocument'
         'COLLECTION': 'http://purl.org/dc/dcmitype/Collection'
         'COMMUNITY': 'http://purl.org/dc/dcmitype/Collection'
+        'UNKNOWN': 'https://schema.org/DigitalDocument'
     - plugin: skip_on_empty
       method: row
       message: 'Failed to map the dspace type to an islandora model.'
@@ -242,7 +287,7 @@ process:
       value: 'http://purl.org/dc/dcmitype/Collection'
     - plugin: dgi_migrate.process.static_map
       source: '@_i8_model_uri'
-      bypass: true
+      default_value: []
       map:
         - ['https://schema.org/DigitalDocument', ['http://mozilla.github.io/pdf.js']]
         - ['http://purl.org/coar/resource_type/c_c513', ['http://openseadragon.github.io']]
@@ -497,7 +542,7 @@ process:
           - plugin: get
             source: parent_value
           - plugin: dgi_migrate_edtf_validator
-            intervals: false
+            intervals: true
             strict: true
         field_event_type:
           - plugin: default_value
@@ -522,7 +567,7 @@ process:
           - plugin: get
             source: parent_value
           - plugin: dgi_migrate_edtf_validator
-            intervals: false
+            intervals: true
             strict: true
         field_event_type:
           - plugin: default_value

--- a/modules/dgi_migrate_dspace/migrations/dgi_dspace_orig_media.yml
+++ b/modules/dgi_migrate_dspace/migrations/dgi_dspace_orig_media.yml
@@ -32,10 +32,12 @@ process:
   # XXX: Somewhat counter-intuitive, but it will just ignore those file field
   # entries with which the target bundle does not deal.
   field_media_audio_file: '@_file'
+  field_media_document: '@_file'
   field_media_file: '@_file'
   field_media_image/target_id: '@_file_id'
   field_media_image/alt: '@name'
   field_media_video_file: '@_file'
+  field_original_name: '@name'
 
   _zip_scheme:
     - plugin: default_value
@@ -86,8 +88,49 @@ process:
     - plugin: static_map
       bypass: false
       map:
-        'application/jpeg': 'image'
-        'application/pdf': 'file'
+        'audio/aac': 'audio'
+        'application/msword': 'file'
+        'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'file'
+        'image/gif': 'image'
+        'image/jp2': 'file'
+        'image/jpeg': 'image'
+        'image/jpg': 'image'
+        'image/pjpeg': 'image'
+        'text/jpg': 'image'
+        'audio/mpeg': 'audio'
+        'audio/mpeg3': 'audio'
+        'audio/x-mpeg': 'audio'
+        'audio/x-mpeg-3': 'audio'
+        'video/x-mpeg': 'audio'
+        'video/mp4': 'video'
+        'application/pdf': 'document'
+        'image/png': 'image'
+        'application/vnd.openxmlformats-officedocument.presentationml.slideshow': 'file'
+        'application/mspowerpoint': 'file'
+        'application/powerpoint': 'file'
+        'application/vnd.ms-powerpoint': 'file'
+        'application/x-mspowerpoint': 'file'
+        'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'file'
+        'application/rtf': 'file'
+        'application/x-rtf': 'file'
+        'text/richtext': 'file'
+        'image/tif': 'file'
+        'image/tiff': 'file'
+        'image/x-tiff': 'file'
+        'text/plain': 'document'
+        'text/html': 'document'
+        'audio/vnd.wave': 'audio'
+        'audio/wav': 'audio'
+        'audio/wave': 'audio'
+        'audio/x-wav': 'audio'
+        'audio/x-wave': 'audio'
+        'application/excel': 'file'
+        'application/vnd.ms-excel': 'file'
+        'application/x-excel': 'file'
+        'application/x-msexcel': 'file'
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'file'
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.template': 'file'
+        'application/vnd.ms-xpsdocument': 'file'
   field_file_size:
     - plugin: dgi_migrate.method
       method: getSize

--- a/modules/dgi_migrate_dspace/migrations/dgi_mets_files.yml
+++ b/modules/dgi_migrate_dspace/migrations/dgi_mets_files.yml
@@ -42,7 +42,7 @@ process:
       default_value: 0
   filemime:
     - plugin: default_value
-      default_value: application/xml
+      default_value: application/zip
 dependencies:
   enforced:
     module:

--- a/modules/dgi_migrate_edtf_validator/src/Plugin/migrate/process/Validator.php
+++ b/modules/dgi_migrate_edtf_validator/src/Plugin/migrate/process/Validator.php
@@ -13,6 +13,7 @@ use Drupal\migrate\Row;
  * Skips processing the current row when the EDTF date isn't valid.
  *
  * Available configuration keys:
+ * - ignore_empty (optional): Boolean to ignore empty values, defaults to TRUE.
  * - intervals (optional): Boolean of whether this field is supporting intervals
  *   or not, defaults to TRUE.
  * - sets (optional): Boolean of whether this field is supporting sets or not,
@@ -38,6 +39,9 @@ class Validator extends ProcessPluginBase implements ConfigurableInterface {
    * {@inheritdoc}
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    if ($this->configuration['ignore_empty'] && empty($value)) {
+      return $value;
+    }
     $errors = EDTFUtils::validate($value, $this->configuration['intervals'], $this->configuration['sets'], $this->configuration['strict']);
     if (!empty($errors)) {
       throw new MigrateSkipRowException(strtr('The value: ":value" for ":property" is not a valid EDTF date: :errors', [
@@ -68,6 +72,7 @@ class Validator extends ProcessPluginBase implements ConfigurableInterface {
    */
   public function defaultConfiguration() {
     return [
+      'ignore_empty' => TRUE,
       'intervals' => TRUE,
       'sets' => TRUE,
       'strict' => FALSE,

--- a/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_nodes.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_nodes.yml
@@ -136,7 +136,7 @@ process:
   field_display_hints:
     - plugin: dgi_migrate.process.static_map
       source: '@_i8_model_uri'
-      bypass: true
+      default_value: []
       map:
         - ['https://schema.org/DigitalDocument', ['http://mozilla.github.io/pdf.js']]
         - ['http://purl.org/coar/resource_type/c_c513', ['http://openseadragon.github.io']]


### PR DESCRIPTION
Prevents the following errors:

- field_display_hints skipping row when not applicable.
- items with no 'ORIGINAL' file being ignored (now default to documents).
- missing mimetype to content model mapping.
- edtf dates support times (requires change to controlled_access_terms).
- missing fields from media content (field_media_document/field_original_name).
- missing mimetype to media mapping.
- zip files mapped to application/xml rather than application/zip.