### PR TITLE
DGI9-27: ImageMagick timeout error when attempting to CSV ingest 200mb image

### DIFF
--- a/src/DgiMigrateServiceProvider.php
+++ b/src/DgiMigrateServiceProvider.php
@@ -9,6 +9,7 @@ use Drupal\Core\DependencyInjection\ServiceProviderBase;
  * Service provider.
  */
 class DgiMigrateServiceProvider extends ServiceProviderBase {
+  const TIMEOUT = 120;
 
   /**
    * {@inheritdoc}
@@ -17,6 +18,10 @@ class DgiMigrateServiceProvider extends ServiceProviderBase {
     if ($container->hasDefinition('migrate.stub')) {
       $container->getDefinition('migrate.stub')
         ->setClass(MigrateStub::class);
+    }
+    if ($container->hasDefinition('imagemagick.exec_manager')) {
+      $container->getDefinition('imagemagick.exec_manager')
+        ->addMethodCall('setTimeout', [self::TIMEOUT]);
     }
   }
 


### PR DESCRIPTION
Timeout currently set to 120 (double the default value of 60). Should be looked at to see if it should maybe be higher or lower?