### PR TITLE
D94-28: Add update hook to ensure the new dependency is enabled.

### DIFF
--- a/dgi_migrate.install
+++ b/dgi_migrate.install
@@ -5,6 +5,10 @@
  * Misc (un)installation and update hooks.
  */
 
+use Drupal\Core\Extension\ExtensionNameLengthException;
+use Drupal\Core\Extension\MissingDependencyException;
+use Drupal\Core\Utility\UpdateException;
+
 /**
  * Delete example migration entities migrated to live as plugins.
  */


### PR DESCRIPTION
Strictly, should also be done in the `dgi_migrate_regenerate_pathauto_aliases` submodule, as it could hypothetically be installed without `dgi_migrate` proper being installed, but the submodule has also gotten the new dependency...

... would be a very rare case... can come back for it if we need it.

... could get into issues with phpcpd, with copypasta and not really any shared code location to put it. Odd case for a submodule?

Just for reference, this update hook implementation is largely copypasta of [that which was employed with the recent introduction of `ctools` to `islandora`](https://github.com/Islandora/islandora/pull/896/files#diff-7f4f37590f2e1f40de7bb2a99e29040b54c0efc09bfd600d9f45816f46160247).