### PR TITLE
LANWTI2-71: Remove the paragraph title character limit

### DIFF
--- a/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_nodes.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_nodes.yml
@@ -1733,7 +1733,6 @@ process:
     - plugin: multiple_values
     - plugin: dgi_standard_title_paragraph
       xpath: '@_mods_xpath'
-      max_length: 255
       validate: *validate
   field_use_and_reproduction:
     - << : *base_mods_node


### PR DESCRIPTION
The `dgi_standard_title_paragraph` plugin defaults to no truncation if `max_length` is not passed.