### PR TITLE
Update migrate_directory version targetting.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
       "discoverygarden/dgi_saxon_helper": "^1",
       "discoverygarden/foxml": "^1",
       "discoverygarden/islandora_drush_utils": "^1",
-      "drupal/migrate_directory": "^1",
+      "drupal/migrate_directory": "^1 || ^2",
       "drupal/migrate_plus": "^5.1",
       "drupal/migrate_tools": "^5.0",
       "drupal/pathauto": "^1.8",


### PR DESCRIPTION
With dgi's fork of `migrate_directory` being phased out the upstream should be used and patched instead.