### PR TITLE
CTDA9-301: Multiprocessing

### DIFF
--- a/dgi_migrate.module
+++ b/dgi_migrate.module
@@ -5,6 +5,8 @@
  * Implements module hooks.
  */
 
+use Drupal\dgi_migrate\Plugin\migrate\process\LockingMigrationLookup;
+
 /**
  * Implements hook_migration_plugins_alter().
  */
@@ -14,4 +16,20 @@ function dgi_migrate_migration_plugins_alter(&$definitions) {
       $definitions[$plugin_id]['idMap']['plugin'] = 'smart_sql';
     }
   }
+}
+
+/**
+ * Implements hook_migrate_TYPE_info_alter() for "process" plugins.
+ */
+function dgi_migrate_migrate_process_info_alter(&$definitions) {
+  $definitions['dgi_migrate_original_migration_lookup'] =
+    [
+      'provider' => 'dgi_migrate',
+      'id' => 'dgi_migrate_original_migration_lookup',
+    ] +
+    $definitions['migration_lookup'];
+
+  $lookup =& $definitions['migration_lookup'];
+  $lookup['class'] = LockingMigrationLookup::class;
+  $lookup['provider'] = 'dgi_migrate';
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -99,6 +99,8 @@ The primary means of encountering race conditions has also been adjusted to atte
 
 Our `migration.sh` script should handle setting the `DGI_MIGRATE__DO_MIGRATION_LOOKUP_LOCKING` variable to the string `TRUE`, which will enable the given locking behaviour.
 
+NOTE: For small sets being migrated, it is likely that the overhead of multiprocessing may out weight the benefits. Initial guesstimate is around a-handful-of-tens to hundreds of items where multiprocessing might become advantageous.
+
 ### Rollback
 
 If additional parameters/options need to be passed to the `dgi-migrate:rollback`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -86,6 +86,19 @@ $ tail -n 23 /tmp/asdf/14-import.log
 	Exit status: 0
 ```
 
+#### Multiprocessing
+
+The default processing will be single-threaded; however, we have built out mechanisms to allow for migrations to be multiprocessed. This mechanism will be activated by `PROCESSES` in the `.env` having a value greater than `1`. When greater than `1`, our migration processing will:
+
+1. Populate a queue in one command, initializing the migration (change the "migration state" to "running")
+2. Spawn `PROCESSES` processes to process the queue
+3. ... wait for the spawned processes to exit (ideally, having finished processing)
+4. And finally tear-down the queue, and finalize the migration (set the "migration state" back to "idle").
+
+The primary means of encountering race conditions has also been adjusted to attempt to serialize lookup/creation, which is to say, in generating entities via `migration_lookup` stubbing.
+
+Our `migration.sh` script should handle setting the `DGI_MIGRATE__DO_MIGRATION_LOOKUP_LOCKING` variable to the string `TRUE`, which will enable the given locking behaviour.
+
 ### Rollback
 
 If additional parameters/options need to be passed to the `dgi-migrate:rollback`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -101,6 +101,11 @@ Our `migration.sh` script should handle setting the `DGI_MIGRATE__DO_MIGRATION_L
 
 NOTE: For small sets being migrated, it is likely that the overhead of multiprocessing may out weight the benefits. Initial guesstimate is around a-handful-of-tens to hundreds of items where multiprocessing might become advantageous.
 
+NOTE: In terms of establishing the `PROCESSES` quantity, there are environmental considerations:
+* Multiprocessing is just to optimize CPU usage; for example, to avoid having CPUs sit unnecessarily idle when there's work to be done.
+* Is Crayfish on the same machine? Are derivatives enabled? There can be additional load from Crayfish acquiring files from Drupal, or if on the same machine, from the derivatives proper being run.
+* Is the site being used by others? If so, it is probably a good idea to play nice and to try to avoid saturating the CPUs, perhaps going so far as to `nice` the migration execution. If not, we could target a slight bit of oversaturation, with the expectation that there will be some background I/O overhead on read/write operations that might leave some CPU cycles otherwise unoccupied.
+
 ### Rollback
 
 If additional parameters/options need to be passed to the `dgi-migrate:rollback`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -88,7 +88,7 @@ $ tail -n 23 /tmp/asdf/14-import.log
 
 #### Multiprocessing
 
-The default processing will be single-threaded; however, we have built out mechanisms to allow for migrations to be multiprocessed. This mechanism will be activated by `PROCESSES` in the `.env` having a value greater than `1`. When greater than `1`, our migration processing will:
+The default processing will be single-threaded; however, we have built out mechanisms to allow for migrations to be multiprocessed. This mechanism will be activated by `PROCESSES` in the `.env` having a value greater than `1`. When greater than `1`, for each migration being executed our migration processing will:
 
 1. Populate a queue in one command, initializing the migration (change the "migration state" to "running")
 2. Spawn `PROCESSES` processes to process the queue

--- a/scripts/env.sample
+++ b/scripts/env.sample
@@ -53,3 +53,8 @@
 # LOG_DIR: The path under which to create log files for migration operations.
 # ---
 # NOTE: Defaults to the directory containing the ".env" file.
+
+# ===
+# PROCESSES: The number of processes to use to run the migration import.
+# ---
+#PROCESSES=1

--- a/scripts/util.in
+++ b/scripts/util.in
@@ -4,6 +4,14 @@ function wwwdo () {
   sudo -u $WEB_USER -- ${@:1}
 }
 
+function wwwdrush () {
+  wwwdo $DRUSH "--root=$DRUPAL_ROOT" "--uri=$URI" ${@:1}
+}
+
+function timedwwwdrush () {
+  wwwdo $TIME --verbose $DRUSH "--root=$DRUPAL_ROOT" "--uri=$URI" ${@:1}
+}
+
 function get_op_number () {
   local NUM=1
   local NUM_FILE="$LOG_DIR/.RUNS"
@@ -56,6 +64,7 @@ function init_vars () {
   declare -g URI=${URI:?Missing URI}
   declare -g TIME=${TIME:-/usr/bin/time}
   declare -g LOG_DIR=${LOG_DIR:-$CONFIG_DIR}
+  declare -g PROCESSES=${PROCESSES:-1}
 
   # Initialize the log directory.
   if ! [ -d "$LOG_DIR" ]; then
@@ -70,6 +79,46 @@ function init_vars () {
   set -u
 }
 
+# Kick off a migration in a single process.
+#
+# Positional args:
+#
+# - 1: The operation number.
+# - 2+: Additional arguments to pass to the dgi-migrate:import command.
+function do_migration_single_process() {
+  # The base import
+  timedwwwdrush dgi-migrate:import "--root=$DRUPAL_ROOT" "--uri=$URI" "--user=$DRUPAL_USER" "--group=$MIGRATION_GROUP" "${@:2}"
+}
+
+# Kick off a migration in multiple processes.
+#
+# Positional args:
+#
+# - 1: The operation number.
+# - 2+: Additional arguments to pass to the migrate commands... only really expecting "--update"
+function do_migration_multi_process() {
+  local NUM=${1}
+
+  local PROCESS_LOG_DIR="$LOG_DIR/$NUM-multiprocess-logs"
+
+  wwwdo mkdir -p $PROCESS_LOG_DIR
+
+  echo "Listing migrations..."
+  timedwwwdrush dgi-migrate:list-migrations "--group=$MIGRATION_GROUP" --format=string \
+    | sort -n --key=2 | cut -f1 | while read MIGRATION_ID; do
+      echo "Enqueuing items for $MIGRATION_ID"
+      timedwwwdrush dgi-migrate:enqueue --user=$DRUPAL_USER $MIGRATION_ID "${@:2}"
+      echo "Starting $PROCESSES processes to process $MIGRATION_ID."
+      for i in $(seq 1 $PROCESSES); do
+        echo "Starting $i/$PROCESSES to process $MIGRATION_ID."
+        timedwwwdrush dgi-migrate:enqueued-process --user=$DRUPAL_USER $MIGRATION_ID "${@:2}" &> $PROCESS_LOG_DIR/$MIGRATION_ID.$i.log &
+      done
+      echo "Waiting for processes to exit..."
+      wait
+      timedwwwdrush dgi-migrate:finish-enqueued-process --user=1 $MIGRATION_ID "${@:2}"
+    done
+}
+
 # Handle kicking off a migration.
 #
 # Positional args:
@@ -82,24 +131,31 @@ function do_migration () {
   local IMPORT_LOG="$LOG_DIR/$NUM-import.log"
   local RUN_LOG="$LOG_DIR/$NUM-run.log"
   local MESSAGES_DIR="$LOG_DIR/$NUM-messages"
+  local PROCESS_LOG_DIR="$LOG_DIR/$NUM-multiprocess-logs"
 
   {
     set -x
     # XXX: Paranoia; a cache rebuild _with_ the URI, to ensure that anything
     # that makes use of the `--uri` to do things will have an appropriate one.
     # (lookin' at you, dgi_migrate_foxml_standard_mods_xslt dealio)
-    wwwdo $DRUSH cache:rebuild "--root=$DRUPAL_ROOT" "--uri=$URI"
+    wwwdrush cache:rebuild
     # Dump status before run.
-    wwwdo $DRUSH migrate:status --root=$DRUPAL_ROOT --uri=$URI --group=$MIGRATION_GROUP
-    # The base import
-    wwwdo $TIME --verbose $DRUSH dgi-migrate:import "--root=$DRUPAL_ROOT" "--uri=$URI" "--user=$DRUPAL_USER" "--group=$MIGRATION_GROUP" "${@:2}" |& wwwdo tee $IMPORT_LOG > /dev/null
+    wwwdrush migrate:status --group=$MIGRATION_GROUP
+    {
+      # Do the import, one way or another.
+      if [ $PROCESSES -eq 1 ]; then
+        do_migration_single_process "$@"
+      else
+        do_migration_multi_process "$@"
+      fi
+    } |& wwwdo tee $IMPORT_LOG > /dev/null
     # Dump status after run.
-    wwwdo $DRUSH migrate:status --root=$DRUPAL_ROOT --uri=$URI --group=$MIGRATION_GROUP
+    wwwdrush migrate:status --group=$MIGRATION_GROUP
     # Dump messages after run, so they're not lost with a subsequent run.
     wwwdo mkdir -p $MESSAGES_DIR
-    wwwdo $DRUSH migrate:status --root=$DRUPAL_ROOT --uri=$URI --group=$MIGRATION_GROUP --field=id --format=string | \
+    wwwdrush migrate:status --group=$MIGRATION_GROUP --field=id --format=string | \
     while read NAME ; do
-      wwwdo $DRUSH migrate:messages --root=$DRUPAL_ROOT --uri=$URI --format=json $NAME | wwwdo tee "$MESSAGES_DIR/$NAME.json" > /dev/null
+      wwwdrush migrate:messages --format=json $NAME | wwwdo tee "$MESSAGES_DIR/$NAME.json" > /dev/null
     done
     set +x
   } |& wwwdo tee $RUN_LOG
@@ -112,6 +168,13 @@ Import command (operation $NUM) terminated; see log files in:
 and the JSON files representing the output messages in:
 - $MESSAGES_DIR
 EOF
+
+  if [ $PROCESSES -gt 1 ]; then
+    cat <<EOF
+Multiprocesed logs should be in:
+- $PROCESS_LOG_DIR
+EOF
+  fi
 }
 
 # Handle kicking off the rollback of a migration.
@@ -131,13 +194,13 @@ function do_rollback () {
     # XXX: Paranoia; a cache rebuild _with_ the URI, to ensure that anything
     # that makes use of the `--uri` to do things will have an appropriate one.
     # (lookin' at you, things involving Fedora dealio)
-    wwwdo $DRUSH cache:rebuild "--root=$DRUPAL_ROOT" "--uri=$URI"
+    wwwdrush cache:rebuild
     # Dump status before rollback.
-    wwwdo $DRUSH migrate:status --root=$DRUPAL_ROOT --uri=$URI --group=$MIGRATION_GROUP
+    wwwdrush migrate:status --group=$MIGRATION_GROUP
     # The base rollback.
-    wwwdo $TIME --verbose $DRUSH dgi-migrate:rollback --root=$DRUPAL_ROOT --uri=$URI --user=$DRUPAL_USER --group=$MIGRATION_GROUP "${@:2}" |& wwwdo tee $ROLLBACK_LOG > /dev/null
+    timedwwwdrush dgi-migrate:rollback --user=$DRUPAL_USER --group=$MIGRATION_GROUP "${@:2}" |& wwwdo tee $ROLLBACK_LOG > /dev/null
     # Dump status after rollback.
-    wwwdo $DRUSH migrate:status --root=$DRUPAL_ROOT --uri=$URI --group=$MIGRATION_GROUP
+    wwwdrush migrate:status --group=$MIGRATION_GROUP
     set +x
   } |& wwwdo tee $RUN_LOG
 

--- a/scripts/util.in
+++ b/scripts/util.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function wwwdo () {
-  sudo -u $WEB_USER -- ${@:1}
+  sudo -u $WEB_USER --preserve-env=DGI_MIGRATE__DO_MIGRATION_LOOKUP_LOCKING -- ${@:1}
 }
 
 function wwwdrush () {
@@ -39,7 +39,7 @@ function get_op_number () {
   printf "%02d\n" $NUM
 }
 
-# Setup variables; further unbound things constitue an error.
+# Setup variables; further unbound things constitute an error.
 #
 # Positional args:
 # - 1: The directory under which to look for the ".env" file. Also the default
@@ -74,6 +74,12 @@ function init_vars () {
   elif ! ( wwwdo test -d "$LOG_DIR" && wwwdo test -w "$LOG_DIR" ); then
     echo "$WEB_USER must be able to write (logs) to the log directory ($LOG_DIR)."
     exit 1;
+  fi
+
+  if [ $PROCESSES -gt 1 ]; then
+    export DGI_MIGRATE__DO_MIGRATION_LOOKUP_LOCKING="TRUE"
+  else
+    export DGI_MIGRATE__DO_MIGRATION_LOOKUP_LOCKING="FALSE"
   fi
 
   set -u
@@ -171,7 +177,7 @@ EOF
 
   if [ $PROCESSES -gt 1 ]; then
     cat <<EOF
-Multiprocesed logs should be in:
+Multiprocessed logs should be in:
 - $PROCESS_LOG_DIR
 EOF
   fi

--- a/src/Commands/MigrateCommands.php
+++ b/src/Commands/MigrateCommands.php
@@ -420,7 +420,7 @@ class MigrateCommands extends MigrateToolsCommands {
   }
 
   /**
-   * Process enqueued entities for a given migration.
+   * Finalize/tear down a migration.
    *
    * @command dgi-migrate:finish-enqueued-process
    *

--- a/src/Commands/MigrateCommands.php
+++ b/src/Commands/MigrateCommands.php
@@ -394,7 +394,7 @@ class MigrateCommands extends MigrateToolsCommands {
         [[$executable, 'processBatch'], []],
       ],
     ];
-    drush_op('batch_set', [$batch]);
+    drush_op('batch_set', $batch);
     drush_op('drush_backend_batch_process');
     drush_op(function () {
       // XXX: Need to reset the batch status before setting and processing
@@ -423,5 +423,5 @@ class MigrateCommands extends MigrateToolsCommands {
     $executable = $this->getExecutable($migration_id, $options);
     drush_op([$executable, 'teardownMigration']);
   }
-  
+
 }

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -344,7 +344,7 @@ class MigrateBatchExecutable extends MigrateExecutable {
     $get_current = function () use (&$sandbox, $queue) {
       return $sandbox['total'] - $queue->numberOfItems();
     };
-    $update_finished = function () use (&$context, &$sandbox, $queue, $get_current) {
+    $update_finished = function () use (&$context, &$sandbox, $get_current) {
       $context['finished'] = $get_current() / $sandbox['total'];
     };
     try {

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -71,10 +71,22 @@ class MigrateBatchExecutable extends MigrateExecutable {
     }
   }
 
+  /**
+   * Helper; build out the name of the queue.
+   *
+   * @return string
+   *   The name of the queue.
+   */
   public function getQueueName() : string {
     return "dgi_migrate__batch_queue__{$this->migration->id()}";
   }
 
+  /**
+   * Lazy-load the queue.
+   *
+   * @return \Drupal\Core\Queue\QueueInterface
+   *   The queue implementation to use.
+   */
   protected function getQueue() : QueueInterface {
     if (!isset($this->queue)) {
       $this->queue = \Drupal::queue($this->getQueueName(), TRUE);
@@ -149,8 +161,11 @@ class MigrateBatchExecutable extends MigrateExecutable {
     $this->teardownMigration();
   }
 
+  /**
+   * Helper; signal the cleanup and signal we are done.
+   */
   public function teardownMigration() {
-    $this->queue->deleteQueue();
+    $this->getQueue()->deleteQueue();
     $this->getEventDispatcher()->dispatch(MigrateEvents::POST_IMPORT, new MigrateImportEvent($this->migration, $this->message));
     $this->migration->setStatus(MigrationInterface::STATUS_IDLE);
   }
@@ -211,9 +226,10 @@ class MigrateBatchExecutable extends MigrateExecutable {
     }
 
     // XXX: Nuke it, just in case.
-    $this->queue->deleteQueue();
+    $queue = $this->getQueue();
+    $queue->deleteQueue();
     foreach ($source as $row) {
-      $this->queue->createItem([
+      $queue->createItem([
         'row' => $row,
         'attempts' => 0,
       ]);
@@ -316,7 +332,6 @@ class MigrateBatchExecutable extends MigrateExecutable {
     $sandbox =& $context['sandbox'];
 
     if (!isset($sandbox['total'])) {
-      $sandbox['current'] = 0;
       $sandbox['total'] = $this->queue->numberOfItems();
       if ($sandbox['total'] === 0) {
         $context['message'] = $this->t('Queue empty.');
@@ -325,10 +340,17 @@ class MigrateBatchExecutable extends MigrateExecutable {
       }
     }
 
+    $queue = $this->getQueue();
+    $get_current = function () use (&$sandbox, $queue) {
+      return $sandbox['total'] - $queue->numberOfItems();
+    };
+    $update_finished = function () use (&$context, &$sandbox, $queue, $get_current) {
+      $context['finished'] = $get_current() / $sandbox['total'];
+    };
     try {
-      $context['finished'] = $sandbox['current'] / $sandbox['total'];
+      $update_finished();
       while ($context['finished'] < 1) {
-        $item = $this->queue->claimItem();
+        $item = $queue->claimItem();
         if (!$item) {
           // XXX: Exceptions for flow control... maybe not the best, but works
           // for now... as such, let's allow it to pass translated messages.
@@ -349,10 +371,9 @@ class MigrateBatchExecutable extends MigrateExecutable {
 
         try {
           $status = $this->processRowFromQueue($row);
-          ++$sandbox['current'];
           $context['message'] = $this->t('Migration "@migration": @current/@total; processed row with IDs: (@ids)', [
             '@migration' => $this->migration->id(),
-            '@current'   => $sandbox['current'],
+            '@current'   => $get_current(),
             '@ids'       => var_export($row->getSourceIdValues(), TRUE),
             '@total'     => $sandbox['total'],
           ]);
@@ -362,7 +383,7 @@ class MigrateBatchExecutable extends MigrateExecutable {
             // phpcs:ignore DrupalPractice.General.ExceptionT.ExceptionT
             throw new MigrateBatchException($this->t('Stopping "@migration" after @current of @total', [
               '@migration' => $this->migration->id(),
-              '@current' => $sandbox['current'],
+              '@current' => $get_current(),
               '@total' => $sandbox['total'],
             ]), 1);
           }
@@ -383,7 +404,7 @@ class MigrateBatchExecutable extends MigrateExecutable {
             // increment 'current'.
             $context['message'] = $this->t('Migration "@migration": @current/@total; encountered exception processing row with IDs: (@ids); re-enqueueing. Exception info:@n@ex', [
               '@migration' => $this->migration->id(),
-              '@current'   => $sandbox['current'],
+              '@current'   => $get_current(),
               '@ids'       => var_export($row->getSourceIdValues(), TRUE),
               '@total'     => $sandbox['total'],
               '@ex'        => $e,
@@ -392,7 +413,6 @@ class MigrateBatchExecutable extends MigrateExecutable {
             $this->queue->createItem($item->data);
           }
           else {
-            ++$sandbox['current'];
             $context['message'] = $this->t('Migration "@migration": @current/@total; encountered exception processing row with IDs: (@ids); attempts exhausted, failing. Exception info:@n@ex', [
               '@migration' => $this->migration->id(),
               '@current'   => $sandbox['current'],
@@ -405,10 +425,10 @@ class MigrateBatchExecutable extends MigrateExecutable {
           }
         }
         finally {
-          $this->queue->deleteItem($item);
+          $queue->deleteItem($item);
         }
 
-        $context['finished'] = $sandbox['current'] / $sandbox['total'];
+        $update_finished();
       }
     }
     catch (MigrateBatchException $e) {
@@ -416,7 +436,12 @@ class MigrateBatchExecutable extends MigrateExecutable {
         $context['message'] = $msg;
       }
 
-      $context['finished'] = $e->getFinished() ?? ($sandbox['current'] / $sandbox['total']);
+      if ($e->getFinished() !== NULL) {
+        $context['finished'] = $e->getFinished();
+      }
+      else {
+        $update_finished();
+      }
     }
 
   }

--- a/src/Plugin/migrate/process/LockingMigrationLookup.php
+++ b/src/Plugin/migrate/process/LockingMigrationLookup.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Drupal\dgi_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateException;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrateProcessInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Override upstream `migration_lookup` plugin, with some additional locking.
+ *
+ * Ideally, could avoid locking by default... require setting an environment
+ * variables (and checking for it), to avoid locking in single-threaded
+ * contexts?
+ */
+class LockingMigrationLookup extends ProcessPluginBase implements MigrateProcessInterface, ContainerFactoryPluginInterface {
+
+  const CONTROL_LOCK = 'dgi_migrate_locking_migration_lookup_lock';
+
+  protected MigrateProcessInterface $parent;
+  protected LockBackendInterface $lock;
+  protected array $migrations;
+  protected bool $hasControl = FALSE;
+  protected array $lockMap;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->migrations = (array) $configuration['migration'];
+    if (array_key_exists('source_ids', $configuration)) {
+      $this->migrations = array_merge($this->migrations, array_keys($configuration['source_ids']));
+    }
+    if (array_key_exists('stub_id', $configuration)) {
+      $this->migrations[] = $configuration['stub_id'];
+    }
+    $this->migrations = array_unique($this->migrations);
+  }
+
+  protected function getMigrations() {
+    if (!isset($this->migrations)) {
+      $this->migrations = (array) $this->configuration['migration'];
+      if (array_key_exists('source_ids', $this->configuration)) {
+        $this->migrations = array_merge($this->migrations, array_keys($this->configuration['source_ids']));
+      }
+      if (array_key_exists('stub_id', $this->configuration)) {
+        $this->migrations[] = $this->configuration['stub_id'];
+      }
+      $this->migrations = array_unique($this->migrations);
+    }
+
+    return $this->migrations;
+  }
+
+  protected function getLockMap() {
+    if (!isset($this->lockMap)) {
+      $this->lockMap = array_combine($this->getMigrations(), array_map([$this, 'getLockName'], $this->getMigrations()));
+    }
+
+    return $this->lockMap;
+  }
+
+  protected function getLockName(string $migration_name) {
+    // XXX: May have to get creative with hashing... thinking max lock name is
+    // something like 255 chars?
+    return "dgi_migrate_locking_migration_lookup__migration_$migration_name";
+  }
+
+  protected function acquireMigrationLocks(float $timeout = 30.0) {
+    foreach ($this->getLockMap() as $migration => $lock_name) {
+      if (!$this->lock->acquire($lock_name, $timeout)) {
+        throw new MigrateException("Failed to acquire lock for '$migration'.");
+      }
+    }
+  }
+  protected function releaseMigrationLocks() {
+    foreach ($this->getLockMap() as $lock_name) {
+      $this->lock->release($lock_name);
+    }
+  }
+
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    try {
+      // Acquire lock-control lock.
+      while (!$this->lock->acquire(static::CONTROL_LOCK, 600)) {}
+      $this->hasControl = TRUE;
+      // Acquire locks for all referenced migrations.
+      $this->acquireMigrationLocks();
+      // Drop lock control lock.
+      $this->lock->release(static::CONTROL_LOCK);
+      $this->hasControl = FALSE;
+      // Perform the lookup as per the wrapped transform.
+      return $this->parent->transform($value, $migrate_executable, $row, $destination_property);
+    }
+    finally {
+      if ($this->hasControl) {
+        $this->lock->release(static::CONTROL_LOCK);
+        $this->hasControl = FALSE;
+      }
+
+      // Drop migration locks.
+      $this->releaseMigrationLocks();
+    }
+
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
+    $instance = new static($configuration, $plugin_id, $plugin_definition);
+
+    /** @var \Drupal\Component\Plugin\PluginManagerInterface $process_plugin_manager */
+    $process_plugin_manager = $container->get('plugin.manager.migrate.process');
+    $instance->parent = $process_plugin_manager->createInstance('dgi_migrate_original_migration_lookup', $configuration, $migration);
+    $instance->lock = $container->get('lock');
+
+    return $instance;
+  }
+
+}

--- a/src/Plugin/migrate/process/LockingMigrationLookup.php
+++ b/src/Plugin/migrate/process/LockingMigrationLookup.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dgi_migrate\Plugin\migrate\process;
 
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Lock\LockBackendInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateException;
@@ -22,27 +23,71 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class LockingMigrationLookup extends ProcessPluginBase implements MigrateProcessInterface, ContainerFactoryPluginInterface {
 
   const CONTROL_LOCK = 'dgi_migrate_locking_migration_lookup_lock';
+  const DEBUG = FALSE;
 
+  /**
+   * The wrapped `migration_lookup` plugin to do the work proper.
+   *
+   * @var \Drupal\migrate\Plugin\MigrateProcessInterface
+   */
   protected MigrateProcessInterface $parent;
+
+  /**
+   * Lock service.
+   *
+   * @var \Drupal\Core\Lock\LockBackendInterface
+   */
   protected LockBackendInterface $lock;
+
+  /**
+   * Memoized array of migrations referenced.
+   *
+   * @var array
+   */
   protected array $migrations;
+
+  /**
+   * Flag if we presently are in possession of the "control" lock.
+   *
+   * @var bool
+   */
   protected bool $hasControl = FALSE;
+
+  /**
+   * Flag if we might be in possession of any "migration" locks.
+   *
+   * @var bool
+   */
+  protected bool $hasMigrationLocks = FALSE;
+
+  /**
+   * Memoized array mapping migration IDs to lock names.
+   *
+   * @var array
+   */
   protected array $lockMap;
 
-  public function __construct(array $configuration, $plugin_id, $plugin_definition) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  /**
+   * The database service.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected Connection $database;
 
-    $this->migrations = (array) $configuration['migration'];
-    if (array_key_exists('source_ids', $configuration)) {
-      $this->migrations = array_merge($this->migrations, array_keys($configuration['source_ids']));
-    }
-    if (array_key_exists('stub_id', $configuration)) {
-      $this->migrations[] = $configuration['stub_id'];
-    }
-    $this->migrations = array_unique($this->migrations);
-  }
+  /**
+   * The migration being executed.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationInterface
+   */
+  protected MigrationInterface $migration;
 
-  protected function getMigrations() {
+  /**
+   * List the migrations referenced by the current plugin.
+   *
+   * @return array
+   *   The migrations referenced by the current plugin.
+   */
+  protected function getMigrations() : array {
     if (!isset($this->migrations)) {
       $this->migrations = (array) $this->configuration['migration'];
       if (array_key_exists('source_ids', $this->configuration)) {
@@ -57,58 +102,150 @@ class LockingMigrationLookup extends ProcessPluginBase implements MigrateProcess
     return $this->migrations;
   }
 
-  protected function getLockMap() {
+  /**
+   * List migrations mapped to lock names.
+   *
+   * @return array
+   *   An associative array mapping migration names to lock names.
+   */
+  protected function getLockMap() : array {
     if (!isset($this->lockMap)) {
-      $this->lockMap = array_combine($this->getMigrations(), array_map([$this, 'getLockName'], $this->getMigrations()));
+      $this->lockMap = array_combine(
+        $this->getMigrations(),
+        array_map([$this, 'getLockName'], $this->getMigrations())
+      );
+    }
+    if (!$this->lockMap) {
+      throw new MigrateException('Failed to map migration IDs to lock names.');
     }
 
     return $this->lockMap;
   }
 
-  protected function getLockName(string $migration_name) {
+  /**
+   * Helper; build out an applicable lock name for a given migration.
+   *
+   * @param string $migration_name
+   *   The migration name/ID for which to generate a lock name.
+   *
+   * @return string
+   *   The lock name to use for the given migration.
+   */
+  protected function getLockName(string $migration_name) : string {
     // XXX: May have to get creative with hashing... thinking max lock name is
     // something like 255 chars?
-    return "dgi_migrate_locking_migration_lookup__migration_$migration_name";
+    // XXX: 255 character limit may be a non-issue?: https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Lock%21DatabaseLockBackend.php/function/DatabaseLockBackend%3A%3AnormalizeName/10
+    return "dgi_migrate_locking_migration_lookup__migration__$migration_name";
   }
 
-  protected function acquireMigrationLocks(float $timeout = 30.0) {
-    foreach ($this->getLockMap() as $migration => $lock_name) {
-      if (!$this->lock->acquire($lock_name, $timeout)) {
-        throw new MigrateException("Failed to acquire lock for '$migration'.");
-      }
-    }
-  }
-  protected function releaseMigrationLocks() {
-    foreach ($this->getLockMap() as $lock_name) {
-      $this->lock->release($lock_name);
-    }
-  }
-
-  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+  /**
+   * Acquire all migration locks.
+   *
+   * @param float $timeout
+   *   The time for which to acquire the locks.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   */
+  protected function acquireMigrationLocks(float $timeout = 30.0) : void {
     try {
-      // Acquire lock-control lock.
-      while (!$this->lock->acquire(static::CONTROL_LOCK, 600)) {}
-      $this->hasControl = TRUE;
-      // Acquire locks for all referenced migrations.
-      $this->acquireMigrationLocks();
-      // Drop lock control lock.
-      $this->lock->release(static::CONTROL_LOCK);
-      $this->hasControl = FALSE;
-      // Perform the lookup as per the wrapped transform.
-      return $this->parent->transform($value, $migrate_executable, $row, $destination_property);
+      if (!$this->getControlLock()) {
+        throw new MigrateException('Failed to acquire control lock.');
+      }
+      if (!$this->hasMigrationLocks) {
+        $this->hasMigrationLocks = TRUE;
+        foreach ($this->getLockMap() as $migration => $lock_name) {
+          while (!$this->lock->acquire($lock_name, $timeout)) {
+            while ($this->lock->wait($lock_name));
+          }
+          if (!$this->lock->acquire($lock_name, $timeout)) {
+            throw new MigrateException("Failed to acquire lock for '$migration'.");
+          }
+        }
+      }
     }
     finally {
-      if ($this->hasControl) {
-        $this->lock->release(static::CONTROL_LOCK);
-        $this->hasControl = FALSE;
-      }
+      $this->releaseControlLock();
+    }
+  }
 
-      // Drop migration locks.
+  /**
+   * Release all migration locks.
+   *
+   * @throws \Drupal\migrate\MigrateException
+   */
+  protected function releaseMigrationLocks() : void {
+    if ($this->hasMigrationLocks) {
+      foreach ($this->getLockMap() as $lock_name) {
+        $this->lock->release($lock_name);
+      }
+      $this->hasMigrationLocks = FALSE;
+    }
+  }
+
+  /**
+   * Helper; acquire control lock.
+   *
+   * @return bool
+   *   TRUE if we acquired it; otherwise, FALSE.
+   */
+  protected function getControlLock() : bool {
+    while (!($this->hasControl = $this->lock->acquire(static::CONTROL_LOCK, 600))) {
+      while ($this->lock->wait(static::CONTROL_LOCK));
+    }
+    return $this->hasControl;
+  }
+
+  /**
+   * Helper; release control lock.
+   */
+  protected function releaseControlLock() {
+    if ($this->hasControl) {
+      $this->lock->release(static::CONTROL_LOCK);
+      $this->hasControl = FALSE;
+    }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $log = function ($message, $level = MigrationInterface::MESSAGE_INFORMATIONAL) use ($row, $destination_property) {
+      if (isset($this->migration) && static::DEBUG) {
+        $this->migration->getIdMap()->saveMessage($row->getSourceIdValues(), "$destination_property: $message", $level);
+      }
+    };
+    $transaction = $this->database->startTransaction();
+    try {
+      // Acquire locks for all referenced migrations.
+      $log('Locking migrations.');
+      $this->acquireMigrationLocks();
+      $log('Locked migrations, running parent.');
+
+      // Perform the lookup as per the wrapped transform.
+      $result = $this->parent->transform($value, $migrate_executable, $row, $destination_property);
+      $log("Parent run, commit transaction and releasing migration locks.");
+      unset($transaction);
+      // Optimistically drop migration locks.
+      $this->releaseMigrationLocks();
+      $log("Releasing migration locks, returning.");
+      return $result;
+    }
+    catch (\Exception $e) {
+      if (isset($transaction)) {
+        $transaction->rollBack();
+      }
+      throw $e;
+    }
+    finally {
+      // Drop migration locks, if we still have them.
       $this->releaseMigrationLocks();
     }
 
   }
 
+  /**
+   * {@inheritDoc}
+   */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
     $instance = new static($configuration, $plugin_id, $plugin_definition);
 
@@ -116,6 +253,8 @@ class LockingMigrationLookup extends ProcessPluginBase implements MigrateProcess
     $process_plugin_manager = $container->get('plugin.manager.migrate.process');
     $instance->parent = $process_plugin_manager->createInstance('dgi_migrate_original_migration_lookup', $configuration, $migration);
     $instance->lock = $container->get('lock');
+    $instance->database = $container->get('database');
+    $instance->migration = $migration;
 
     return $instance;
   }


### PR DESCRIPTION
- command to list migrations in dependency order (accepting `--group` and/or `--tag`)
  - ```
    sudo -u www-data -- env -C /opt/www/drupal COMPOSER_HOME=/var/local/composer composer exec -- drush --uri=http://$(hostname) dgi-migrate:list-migrations --group=foxml_to_dgis --format=string | sort -n --key=2 | cut -f1
    ```
- command to accept a migration ID and start the migration, populating the queue and
  - ```
    sudo -u www-data -- env -C /opt/www/drupal COMPOSER_HOME=/var/local/composer composer exec -- drush --uri=http://$(hostname) dgi-migrate:enqueue {migration_id}
    ```
- command to process from the queue, which can be run multiple times in parallel
  - ```
    sudo -u www-data -- env -C /opt/www/drupal COMPOSER_HOME=/var/local/composer composer exec -- drush --uri=http://$(hostname) dgi-migrate:enqueued-process {}
    ```
- command to accept a migration ID and _stop_ the migration
  - ```
    sudo -u www-data -- env -C /opt/www/drupal COMPOSER_HOME=/var/local/composer composer exec -- drush --uri=http://$(hostname) dgi-migrate:finish-enqueued-process {}
    ```
    
All together, could go something like:    

```bash
#!/bin/bash

WWW_USER=www-data
DRUPAL_ROOT=/opt/www/drupal
COMPOSER_HOME=/var/local/composer
DRUPAL_URI=http://$(hostname)
DRUPAL_USER=1
PROCESSES=10
MIGRATION_GROUP=foxml_to_dgis
LOG_DIRECTORY=logs

function wwwdrush() {
  sudo -u $WWW_USER -- env -C $DRUPAL_ROOT COMPOSER_HOME=$COMPOSER_HOME composer exec -- drush --uri=$DRUPAL_URI $@
}

mkdir -p $LOG_DIRECTORY
wwwdrush dgi-migrate:list-migrations --group=$MIGRATION_GROUP --format=string | sort -n --key=2 | cut -f1 | while read MIGRATION_ID; do
  echo "Enqueuing $MIGRATION_ID"
  wwwdrush dgi-migrate:enqueue --user=$DRUPAL_USER $MIGRATION_ID
  echo "Starting $PROCESSES process(es) to process the queue."
  for i in $(seq 1 $PROCESSES); do
        echo "Starting $i/$PROCESSES..."
        wwwdrush dgi-migrate:enqueued-process --user=$DRUPAL_USER $MIGRATION_ID &> $LOG_DIRECTORY/$MIGRATION_ID.$i.log &
  done
  echo "Waiting for processes to exit..."
  wait
  wwwdrush dgi-migrate:finish-enqueued-process --user=1 $MIGRATION_ID
done
```

---

Got things integrated into the usual `migration.sh` script, such that if `PROCESSES` > 1, it should do the multiprocessing, and handle enabling our locking stuff.