### PR TITLE
D10-9: Update to account for newer `migrate_tools`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/imagemagick": "^3.2",
         "drupal/migrate_directory": "^1 || ^2",
         "drupal/migrate_plus": "^5.1 || ^6",
-        "drupal/migrate_tools": "^5.0",
+        "drupal/migrate_tools": "^6",
         "drupal/paragraphs": "^1",
         "drupal/pathauto": "^1.8",
         "islandora/controlled_access_terms": "^2",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/imagemagick": "^3.2",
         "drupal/migrate_directory": "^1 || ^2",
         "drupal/migrate_plus": "^5.1 || ^6",
-        "drupal/migrate_tools": "^5.0 || ^6",
+        "drupal/migrate_tools": "^5.0",
         "drupal/paragraphs": "^1",
         "drupal/pathauto": "^1.8",
         "islandora/controlled_access_terms": "^2",

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,6 +1,8 @@
+---
 services:
   dgi_migrate.commands:
-    class: \Drupal\dgi_migrate\Commands\MigrateCommands
-    arguments: ['@plugin.manager.migration', '@date.formatter', '@entity_type.manager', '@keyvalue']
+    class: \Drupal\dgi_migrate\Drush\Commands\MigrateCommands
+    factory: [null, create]
+    arguments: ['@service_container']
     tags:
       - { name: drush.command }

--- a/src/Commands/MigrateCommands.php
+++ b/src/Commands/MigrateCommands.php
@@ -5,9 +5,9 @@ namespace Drupal\dgi_migrate\Commands;
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Component\Graph\Graph;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
-use Drupal\migrate_tools\Commands\MigrateToolsCommands;
 use Drupal\dgi_migrate\MigrateBatchExecutable;
 use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate_tools\Drush\MigrateToolsCommands;
 use Drupal\migrate_tools\MigrateTools;
 
 /**
@@ -95,7 +95,7 @@ class MigrateCommands extends MigrateToolsCommands {
   /**
    * {@inheritdoc}
    */
-  protected function executeMigration(MigrationInterface $migration, $migration_id, array $options = []) {
+  protected function executeMigration(MigrationInterface $migration, $migration_id, array $options = []) : void {
     // Keep track of all migrations run during this command so the same
     // migration is not run multiple times.
     static $executed_migrations = [];
@@ -237,7 +237,7 @@ class MigrateCommands extends MigrateToolsCommands {
     'skip-progress-bar' => FALSE,
     'continue-on-failure' => FALSE,
     'statuses' => self::REQ,
-  ]) {
+  ]) : void {
     $group_names = $options['group'];
     $tag_names = $options['tag'];
     $all = $options['all'];

--- a/src/Commands/MigrateCommands.php
+++ b/src/Commands/MigrateCommands.php
@@ -6,8 +6,10 @@ use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Component\Graph\Graph;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\dgi_migrate\MigrateBatchExecutable;
+use Drupal\migrate\MigrateMessageInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate_tools\Drush\MigrateToolsCommands;
+use Drupal\migrate_tools\Drush9LogMigrateMessage;
 use Drupal\migrate_tools\MigrateTools;
 
 /**
@@ -360,6 +362,19 @@ class MigrateCommands extends MigrateToolsCommands {
     /** @var \Drupal\migrate\Plugin\MigrationInterface $migration */
     $migration = $this->migrationPluginManager->createInstance($migration_id);
     return new MigrateBatchExecutable($migration, $this->getMigrateMessage(), $options);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function getMigrateMessage() : Drush9LogMigrateMessage {
+    if (!isset($this->migrateMessage)) {
+      $this->migrateMessage = new Drush9LogMigrateMessage(
+        \Drupal::service('logger.channel.migrate_tools')
+      );
+    }
+
+    return parent::getMigrateMessage();
   }
 
   /**

--- a/src/Drush/Commands/MigrateCommands.php
+++ b/src/Drush/Commands/MigrateCommands.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Drupal\dgi_migrate\Commands;
+namespace Drupal\dgi_migrate\Drush\Commands;
 
 use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\Component\Graph\Graph;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\dgi_migrate\MigrateBatchExecutable;
-use Drupal\migrate\MigrateMessageInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate_tools\Drush\MigrateToolsCommands;
 use Drupal\migrate_tools\Drush9LogMigrateMessage;
 use Drupal\migrate_tools\MigrateTools;
+use Psr\Log\LoggerInterface;
 
 /**
  * Migration command.
@@ -90,8 +90,8 @@ class MigrateCommands extends MigrateToolsCommands {
     'execute-dependencies' => FALSE,
     'skip-progress-bar' => FALSE,
     'sync' => FALSE,
-  ]) {
-    return parent::import($migration_names, $options);
+  ]) : void {
+    parent::import($migration_names, $options);
   }
 
   /**
@@ -370,11 +370,26 @@ class MigrateCommands extends MigrateToolsCommands {
   protected function getMigrateMessage() : Drush9LogMigrateMessage {
     if (!isset($this->migrateMessage)) {
       $this->migrateMessage = new Drush9LogMigrateMessage(
-        \Drupal::service('logger.channel.migrate_tools')
+        // XXX: Something about the default of `$this->logger()` used in the
+        // parent implementation just... doesn't work?
+        static::getMigrateToolsLogger()
       );
     }
 
     return parent::getMigrateMessage();
+  }
+
+  /**
+   * Helper; get fresh logger instance.
+   *
+   * Something seems to be awry with how loggers are passed along during
+   * batches. Let's just side-step the issue.
+   *
+   * @return \Psr\Log\LoggerInterface
+   *   Logger from the service container.
+   */
+  protected static function getMigrateToolsLogger() : LoggerInterface {
+    return \Drupal::service('logger.channel.migrate_tools');
   }
 
   /**

--- a/src/Form/MigrationExecuteForm.php
+++ b/src/Form/MigrationExecuteForm.php
@@ -16,7 +16,7 @@ class MigrationExecuteForm extends MigrationExecuteFormBase {
   /**
    * {@inheritdoc}
    */
-  public function submitForm(array &$form, FormStateInterface $form_state) {
+  public function submitForm(array &$form, FormStateInterface $form_state) : void {
 
     $operation = $form_state->getValue('operation');
 

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -4,6 +4,7 @@ namespace Drupal\dgi_migrate;
 
 use Drupal\Core\Queue\QueueInterface;
 use Drupal\migrate\MigrateException;
+use Drupal\migrate_tools\IdMapFilter;
 use Drupal\migrate_tools\MigrateExecutable;
 use Drupal\migrate\Event\MigrateEvents;
 use Drupal\migrate\Event\MigrateImportEvent;
@@ -525,7 +526,7 @@ class MigrateBatchExecutable extends MigrateExecutable {
   /**
    * {@inheritdoc}
    */
-  protected function getIdMap() {
+  protected function getIdMap() : IdMapFilter {
     return new StatusFilter(parent::getIdMap(), $this->idMapStatuses);
   }
 

--- a/src/StatusFilter.php
+++ b/src/StatusFilter.php
@@ -3,11 +3,12 @@
 namespace Drupal\dgi_migrate;
 
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
+use Drupal\migrate_tools\IdMapFilter;
 
 /**
  * Id map status filter iterator.
  */
-class StatusFilter extends \FilterIterator {
+class StatusFilter extends IdMapFilter {
 
   /**
    * Mapping of human-friendly machine names for to represent the constants.
@@ -29,14 +30,14 @@ class StatusFilter extends \FilterIterator {
   /**
    * Constructor.
    *
-   * @param \Iterator $child
+   * @param \Drupal\migrate\Plugin\MigrateIdMapInterface $child
    *   An upstream iterator/ID map which we are filtering.
    * @param array $statuses
    *   An array of MigrateIdMapInterface::STATUS_* values to which we will
    *   constrain iteration.
    */
-  public function __construct(\Iterator $child, array $statuses) {
-    parent::__construct($child);
+  public function __construct(MigrateIdMapInterface $child, array $statuses) {
+    parent::__construct($child, []);
 
     $this->statuses = $statuses;
   }
@@ -44,7 +45,7 @@ class StatusFilter extends \FilterIterator {
   /**
    * {@inheritdoc}
    */
-  public function accept() {
+  public function accept() : bool {
     if (empty($this->statuses)) {
       return TRUE;
     }


### PR DESCRIPTION
The contained #116 should go in before this (and possibly drop any previously released tag, with the incompatible versions)

... may not _strictly_ have to be a "major" bump. Really, should possibly be "patch", and those envs that can't use the newer version should just avoid pulling it? Dunno. Seems cleaner to just cut a "major" now, and if we have to backport things to the previous major, we can do so.