### PR TITLE
D10-9: Drop `drupal/migrate_tools:^6`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/imagemagick": "^3.2",
         "drupal/migrate_directory": "^1 || ^2",
         "drupal/migrate_plus": "^5.1 || ^6",
-        "drupal/migrate_tools": "^5.0 || ^6",
+        "drupal/migrate_tools": "^5.0",
         "drupal/paragraphs": "^1",
         "drupal/pathauto": "^1.8",
         "islandora/controlled_access_terms": "^2",


### PR DESCRIPTION
The two versions cannot actually be supported in parallel, due to things moving in the namespace and the introduction of type hints.

Should go in before #115 (and possibly drop any previously released tag, with the incompatible versions)
