### PR TITLE
SEC-611: Update stomp queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "drupal/imagemagick": "^3.2",
         "drupal/migrate_directory": "^1 || ^2",
         "drupal/migrate_plus": "^5.1 || ^6",
-        "drupal/migrate_tools": "^6",
+        "drupal/migrate_tools": "^6.0.4",
         "drupal/paragraphs": "^1",
         "drupal/pathauto": "^1.8",
         "islandora/controlled_access_terms": "^2",

--- a/src/Drush/Commands/MigrateCommands.php
+++ b/src/Drush/Commands/MigrateCommands.php
@@ -8,7 +8,7 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\dgi_migrate\StompQueue;
 use Drupal\dgi_migrate\MigrateBatchExecutable;
 use Drupal\migrate\Plugin\MigrationInterface;
-use Drupal\migrate_tools\Drush\MigrateToolsCommands;
+use Drupal\migrate_tools\Drush\Commands\MigrateToolsCommands;
 use Drupal\migrate_tools\Drush9LogMigrateMessage;
 use Drupal\migrate_tools\MigrateTools;
 use Psr\Log\LoggerInterface;


### PR DESCRIPTION
Updating stomp-queue PR with updates to allow for the most recent migrate_tools update where namespacing was changed.