### PR TITLE
Removing redefinition of logger variable

### DIFF
--- a/modules/dgi_migrate_regenerate_pathauto_aliases/src/Commands/Pathauto.php
+++ b/modules/dgi_migrate_regenerate_pathauto_aliases/src/Commands/Pathauto.php
@@ -41,13 +41,6 @@ class Pathauto extends DrushCommands {
   protected $entityTypeBundleInfo;
 
   /**
-   * Logger.
-   *
-   * @var \Psr\Log\LoggerInterface
-   */
-  protected $logger;
-
-  /**
    * Constructor.
    *
    * @param \Drupal\pathauto\PathautoGeneratorInterface $pathauto_generator


### PR DESCRIPTION
This PR corrects an error related to redefining a variable that is already being created as part of the parent class:
```
PHP Fatal error:  Type of Drupal\dgi_migrate_regenerate_pathauto_aliases\Commands\Pathauto::$logger must be ?Psr\Log\LoggerInterface (as in class Drush\Commands\DrushCommands) in /opt/www/drupal/web/modules/contrib/dgi_migrate/modules/dgi_migrate_regenerate_pathauto_aliases/src/Commands/Pathauto.php on line 17
 [warning] Drush command terminated abnormally.
 ```