### PR TITLE
Avoid use of `\SplFileInfo()`.

### DIFF
--- a/modules/dgi_migrate_foxml_standard_mods/src/Plugin/migrate/process/FoxmlFile.php
+++ b/modules/dgi_migrate_foxml_standard_mods/src/Plugin/migrate/process/FoxmlFile.php
@@ -94,7 +94,7 @@ class FoxmlFile extends ProcessPluginBase implements ContainerFactoryPluginInter
         $row,
         $destination_property,
       ),
-      'direct' => static::ensureNonWritable($value),
+      'direct' => $this->ensureNonWritable($value),
     };
   }
 

--- a/src/Plugin/migrate/process/EnsureNonWritableTrait.php
+++ b/src/Plugin/migrate/process/EnsureNonWritableTrait.php
@@ -49,7 +49,7 @@ trait EnsureNonWritableTrait {
         '{path}' => $path,
       ]));
     }
-    if (is_writable($this->fileSystem->dirname($path))) {
+    if (is_writable($this->getFileSystem()->dirname($path))) {
       throw new MigrateSkipRowException(strtr('Directory of source ({path}) appears writable(/deletable); skipping row.', [
         '{path}' => $path,
       ]));

--- a/src/Plugin/migrate/process/EnsureNonWritableTrait.php
+++ b/src/Plugin/migrate/process/EnsureNonWritableTrait.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dgi_migrate\Plugin\migrate\process;
 
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\migrate\MigrateSkipRowException;
 
 /**
@@ -27,36 +28,55 @@ trait EnsureNonWritableTrait {
    * @throws \Drupal\migrate\MigrateSkipRowException
    *   If the file appears to be writable/deletable.
    */
-  protected static function ensureNonWritable(string $path) : string {
-    $file = new \SplFileInfo($path);
-
-    if (!$file->isFile()) {
+  protected function ensureNonWritable(string $path) : string {
+    if (!is_file($path)) {
       throw new MigrateSkipRowException(strtr('Source ({path}) does not appear to be a plain file; skipping row.', [
         '{path}' => $path,
       ]));
     }
-    if ($file->isDir()) {
+    if (is_dir($path)) {
       throw new MigrateSkipRowException(strtr('Source ({path}) appears to be a directory; skipping row.', [
         '{path}' => $path,
       ]));
     }
-    if (!$file->isReadable()) {
+    if (!is_readable($path)) {
       throw new MigrateSkipRowException(strtr('Source ({path}) does not appear to be readable; skipping row.', [
         '{path}' => $path,
       ]));
     }
-    if ($file->isWritable()) {
+    if (is_writable($path)) {
       throw new MigrateSkipRowException(strtr('Source ({path}) appears to be writable(/deletable); skipping row.', [
         '{path}' => $path,
       ]));
     }
-    if ($file->getPathInfo()?->isWritable()) {
+    if (is_writable($this->fileSystem->dirname($path))) {
       throw new MigrateSkipRowException(strtr('Directory of source ({path}) appears writable(/deletable); skipping row.', [
         '{path}' => $path,
       ]));
     }
 
     return $path;
+  }
+
+  /**
+   * Drupal's file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected FileSystemInterface $fileSystem;
+
+  /**
+   * Accessor for Drupal's file system service.
+   *
+   * @return \Drupal\Core\File\FileSystemInterface
+   *   Drupal's file system service.
+   */
+  protected function getFileSystem() : FileSystemInterface {
+    if (!isset($this->fileSystem)) {
+      $this->fileSystem = \Drupal::service('file_system');
+    }
+
+    return $this->fileSystem;
   }
 
 }

--- a/src/Plugin/migrate/process/NonWritable.php
+++ b/src/Plugin/migrate/process/NonWritable.php
@@ -26,7 +26,7 @@ class NonWritable extends ProcessPluginBase {
    * {@inheritDoc}
    */
   public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
-    return static::ensureNonWritable($value);
+    return $this->ensureNonWritable($value);
   }
 
 }


### PR DESCRIPTION
It can cause arbitrary warnings emitted in underlying stream wrappers to be unexpectedly detected and promoted to runtime exceptions. Warnings are warnings and not fatal errors, after all, especially when they are emitted behind the error-suppression operator.

In particular, having a `new \SplFileInfo('foxml://object/{some:pid}');`, and the underlying resolution inside the `foxml://` stream wrapper testing for the existence of various directories, the testing for those directories might in turn perform existence checks for various directories, which in turn cause warnings about being unable to `stat()` those directories that do not exist to be emitted; thereby entirely breaking the testing.