### PR TITLE
[DDST-758] update workflows to their reusable versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,3 +1,4 @@
+---
 name: Code Linting
 on:
   pull_request:
@@ -7,9 +8,4 @@ on:
 
 jobs:
   Lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-      - name: Run CodeSniffer
-        uses: discoverygarden/CodeSniffer@v1
+    uses: discoverygarden/CodeSniffer/.github/workflows/lint.yml@v1

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,13 +1,11 @@
-name: Auto Semver
+---
+name: Semantic Version Tagging
 on:
   pull_request_target:
     types: closed
     branches:
       - main
 jobs:
-  update:
-    if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Auto Semver
-        uses: discoverygarden/auto-semver@v1
+  tag_update:
+    name: Tag Update
+    uses: discoverygarden/auto-semver/.github/workflows/semver.yml@v1


### PR DESCRIPTION
noticed errors in the linting workflow for https://github.com/discoverygarden/dgi_migrate/pull/150, so I copied the more recent lint and semver workflows found in other repos that seem to be working (for example: https://github.com/discoverygarden/dgi_i8_helper/commit/bbaea261fe6c29d2534aadcec47a5b4ec88ec1b4#diff-248962e0d8d239ef3392f051ef2a689de195994852d4b555ff20b7a30f2414d0R2)