### PR TITLE
DDST-905: Remove the dependency on authority_link uri's existence.

### DIFF
--- a/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_stub_terms_corporate_body.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_stub_terms_corporate_body.yml
@@ -44,9 +44,6 @@ process:
         date: date_name_part
         display_form: display_form
   field_authority_link/source:
-    - plugin: skip_on_empty
-      source: auth_value_uri
-      method: process
     - plugin: default_value
       source: auth_source
       default_value: other

--- a/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_stub_terms_generic.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_stub_terms_generic.yml
@@ -33,9 +33,6 @@ process:
   vid: vid
   name: name
   field_authority_link/source:
-    - plugin: skip_on_empty
-      source: auth_value_uri
-      method: process
     - plugin: default_value
       source: auth_source
       default_value: other

--- a/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_stub_terms_person.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/migrations/dgis_stub_terms_person.yml
@@ -50,9 +50,6 @@ process:
         date: date_name_part
         display_form: display_form
   field_authority_link/source:
-    - plugin: skip_on_empty
-      source: auth_value_uri
-      method: process
     - plugin: default_value
       source: auth_source
       default_value: other


### PR DESCRIPTION
Many people create authority_link's without the actual link part, and just the source. We need to make sure that terms are able to be migrated without a link.