### PR TITLE
D11-11: Bump core version, and address some issues flagged by upgrade_status

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "drupal/paragraphs": "^1",
         "drupal/pathauto": "^1.8",
         "iqb/substream": "dev-master",
-        "symfony/mime": "^5 || ^6"
+        "symfony/mime": "^5 || ^6 || ^7"
     },
     "require-dev": {
         "drupal/devel": "^4"

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "extra": {
         "drush": {
             "services": {
-                "drush.11-12.services.yml": "^11.6 || ^12",
+                "drush.11-12.services.yml": ">=11.6",
                 "drush.10-11.services.yml": "^10 || >=11.0.0 <11.6"
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
     "require-dev": {
         "drupal/devel": "^4"
     },
+    "conflict": {
+        "drupal/core": "<10.1"
+    },
     "suggest": {
         "discoverygarden/entity_reference_integrity_extra": "Deal with addtional 'entity_reference' fields.",
         "drupal/entity_reference_integrity": "Used to check things when a migration elects to 'manage_orphans'."

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "discoverygarden/islandora_drush_utils": "^1 || ^2",
         "discoverygarden/update-helper": "^1",
         "drupal/controlled_access_terms": "^2",
-        "drupal/imagemagick": "^3.2",
+        "drupal/imagemagick": "^3.2 || ^4",
         "drupal/islandora": "^2",
         "drupal/migrate_directory": "^1 || ^2",
         "drupal/migrate_plus": "^5.1 || ^6",

--- a/dgi_migrate.info.yml
+++ b/dgi_migrate.info.yml
@@ -2,7 +2,7 @@ name: 'DGI Migrate'
 description: "DGI Migration Support."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:media
   - drupal:migrate

--- a/modules/devel/dgi_migrate_devel.info.yml
+++ b/modules/devel/dgi_migrate_devel.info.yml
@@ -2,7 +2,7 @@ name: DGI Migrate Devel Plugin(s)
 description: "Devel plugins."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate
   - dgi_migrate:dgi_migrate

--- a/modules/dgi_migrate_alter/dgi_migrate_alter.info.yml
+++ b/modules/dgi_migrate_alter/dgi_migrate_alter.info.yml
@@ -2,4 +2,4 @@ name: 'DGI Migrate Alter'
 description: "Allows easy alterations of migrations through plugins."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/modules/dgi_migrate_big_set_overrides/dgi_migrate_big_set_overrides.info.yml
+++ b/modules/dgi_migrate_big_set_overrides/dgi_migrate_big_set_overrides.info.yml
@@ -2,4 +2,4 @@ name: 'DGI Migrate, big set overrides'
 description: "Toggle off some things that take cause issues with resource constraints, while running a migration/batch."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11

--- a/modules/dgi_migrate_dspace/dgi_migrate_dspace.info.yml
+++ b/modules/dgi_migrate_dspace/dgi_migrate_dspace.info.yml
@@ -2,7 +2,7 @@ name: DGI Migrate DSpace
 description: DSpace Migrations to import AIP ZIP exports.
 package: DGI Helpers
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate
   - dgi_migrate:dgi_migrate

--- a/modules/dgi_migrate_edtf_validator/dgi_migrate_edtf_validator.info.yml
+++ b/modules/dgi_migrate_edtf_validator/dgi_migrate_edtf_validator.info.yml
@@ -2,7 +2,7 @@ name: 'DGI Migrate EDTF Validator'
 description: "DGI Migration EDTF Support."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate
   - controlled_access_terms:controlled_access_terms

--- a/modules/dgi_migrate_foxml_standard_mods/dgi_migrate_foxml_standard_mods.info.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/dgi_migrate_foxml_standard_mods.info.yml
@@ -2,7 +2,7 @@ name: DGI Migrate FOXML (Standard MODS)
 description: "FOXML migration for MODS into the DGI standard content type"
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate
   - dgi_migrate:dgi_migrate

--- a/modules/dgi_migrate_foxml_standard_mods/modules/xslt/dgi_migrate_foxml_standard_mods_xslt.info.yml
+++ b/modules/dgi_migrate_foxml_standard_mods/modules/xslt/dgi_migrate_foxml_standard_mods_xslt.info.yml
@@ -2,7 +2,7 @@ name: DGI Migrate FOXML (Standard MODS) XSLT
 description: "XSLT preprocessing for FOXML migration for MODS into the DGI standard content type"
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - dgi_migrate:dgi_migrate
   - dgi_migrate:dgi_migrate_foxml_standard_mods

--- a/modules/dgi_migrate_foxml_standard_mods/tests/src/Kernel/RoleMapperMigrationTest.php
+++ b/modules/dgi_migrate_foxml_standard_mods/tests/src/Kernel/RoleMapperMigrationTest.php
@@ -18,7 +18,7 @@ class RoleMapperMigrationTest extends KernelTestBase {
   /**
    * {@inheritdoc}
    */
-  public static $modules = [
+  protected static $modules = [
     'migrate',
     'dgi_migrate',
     'dgi_migrate_foxml_standard_mods',

--- a/modules/dgi_migrate_foxml_standard_mods/tests/src/Unit/RoleMapperTest.php
+++ b/modules/dgi_migrate_foxml_standard_mods/tests/src/Unit/RoleMapperTest.php
@@ -99,7 +99,7 @@ EOXML
     $roles = $this->plugin->mapRoles($element, $this->xpath);
 
     $this->assertSame($expected_roles, array_intersect($expected_roles, $roles), 'Received found the expected role(s).');
-    $this->assertSame(count($expected_roles), count($roles), 'Had same number of roles.');
+    $this->assertCount(count($expected_roles), $roles, 'Had same number of roles.');
   }
 
   /**

--- a/modules/dgi_migrate_imagemagick_cleanup/dgi_migrate_imagemagick_cleanup.info.yml
+++ b/modules/dgi_migrate_imagemagick_cleanup/dgi_migrate_imagemagick_cleanup.info.yml
@@ -2,7 +2,7 @@ name: 'DGI Migrate Imagemagick Cleanup'
 description: "Imagemagick helper."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate
   - imagemagick:imagemagick

--- a/modules/dgi_migrate_paragraphs/dgi_migrate_paragraphs.info.yml
+++ b/modules/dgi_migrate_paragraphs/dgi_migrate_paragraphs.info.yml
@@ -2,7 +2,7 @@ name: 'DGI Migrate Paragraphs'
 description: "DGI Paragraph Migration Support."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - drupal:migrate
   - paragraphs:paragraphs

--- a/modules/dgi_migrate_regenerate_pathauto_aliases/dgi_migrate_regenerate_pathauto_aliases.info.yml
+++ b/modules/dgi_migrate_regenerate_pathauto_aliases/dgi_migrate_regenerate_pathauto_aliases.info.yml
@@ -2,7 +2,7 @@ name: 'DGI Migrate, regenerate Pathauto aliases'
 description: "Provides a way to regenerate Pathauto aliases that were initially disabled."
 type: module
 package: DGI
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - pathauto:pathauto
   - islandora_drush_utils:islandora_drush_utils

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -108,7 +108,7 @@ class MigrateBatchExecutable extends MigrateExecutable {
   /**
    * {@inheritdoc}
    */
-  public function __sleep() {
+  public function __sleep() : array {
     $vars = $this->traitSleep();
     $to_suppress = [
       // XXX: Avoid serializing some things can't be natively serialized.

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -478,7 +478,10 @@ class MigrateBatchExecutable extends MigrateExecutable {
    * {@inheritdoc}
    */
   protected function checkStatus() {
-    $status = parent::checkStatus();
+    $status = version_compare(\Drupal::VERSION, '11.3.0', '>=') ?
+      MigrationInterface::RESULT_COMPLETED :
+      parent::checkStatus();
+
 
     if ($status === MigrationInterface::RESULT_COMPLETED) {
       if (!static::isCli() && !static::hasTime()) {

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -482,7 +482,6 @@ class MigrateBatchExecutable extends MigrateExecutable {
       MigrationInterface::RESULT_COMPLETED :
       parent::checkStatus();
 
-
     if ($status === MigrationInterface::RESULT_COMPLETED) {
       if (!static::isCli() && !static::hasTime()) {
         return MigrationInterface::RESULT_INCOMPLETE;

--- a/src/Plugin/migrate/id_map/SmartSql.php
+++ b/src/Plugin/migrate/id_map/SmartSql.php
@@ -58,7 +58,7 @@ class SmartSql extends Sql {
 
     // Default generated table names, limited to 63 characters.
     $machine_name = mb_strtolower(str_replace(PluginBase::DERIVATIVE_SEPARATOR, '__', $this->migration->id()));
-    $prefix_length = strlen($this->database->tablePrefix());
+    $prefix_length = strlen($this->database->getPrefix());
     $max_length = self::TABLE_NAME_CHARACTER_LIMIT - $prefix_length;
 
     $map_table_name = self::MAP_TABLE_PREFIX . $machine_name;

--- a/src/Plugin/migrate/source/Migration.php
+++ b/src/Plugin/migrate/source/Migration.php
@@ -97,7 +97,7 @@ class Migration extends SourcePluginBase implements ContainerFactoryPluginInterf
   /**
    * {@inheritdoc}
    */
-  public function __sleep() {
+  public function __sleep() : array {
     $vars = parent::__sleep();
 
     $to_suppress = [

--- a/src/StompQueue.php
+++ b/src/StompQueue.php
@@ -242,7 +242,7 @@ class StompQueue implements QueueInterface {
   /**
    * {@inheritDoc}
    */
-  public function __sleep() {
+  public function __sleep() : array {
     $vars = $this->dstSleep();
 
     $to_suppress = [


### PR DESCRIPTION
Builds on #168 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Drupal core compatibility to support Drupal 10 and 11.
  * Expanded dependency ranges: added ImageMagick v4 and Symfony v7 support.
  * Adjusted module dependencies (including devel and a Saxon helper) and tightened Drush service constraint.
* **Bug Fixes**
  * Improved migration status handling for newer Drupal 11 releases.
* **Tests**
  * Updated tests and assertions for compatibility with the above changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->