### PR TITLE
DGI9-645: Filter destination properties based on available source properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,22 @@ dgi-migrate:rollback beer_user --idlist=5 --user=islandora
 
 ## Configuration
 
+### Search API, direct/immediate indexing
+
 The suppression `search_api`'s "immediate indexing"/`index_directly` functionality (which can cause instability in long processes, when `search_api` attempts to index potentially large sets of entities at the end of the request) is enabled by default, but can be configured by multiple means.
 
 - The `DGI_MIGRATE_SUPPRESS_DIRECT_INDEXING_DURING_MIGRATIONS` environment variables takes precedence if set. The string `true` should enable (case-sensitive!); while any other non-empty value should disable.
 - In config: `dgi_migrate.settings:suppress_direct_indexing_during_migrations`, as a boolean flag.
+
+### Entity update process
+
+Migrations can update existing entities (even without the `--update` flag), should the process identify an existing entity; however, during this process, if all the source properties are not provided for the destination rows that are mapped, it might end up erasing the related fields/properties from the entities in the database.
+
+To permit partial sources to be provided, we have implemented a process to try to track which destination properties did not have a corresponding source property, by implementing some handling around the `get` plugin. Where there is no source properties for an existing entity, existing values should be left intact. If a source property is provided with an empty value, the existing value should be erased.
+
+This functionality is enabled by default; however, it might be disabled by specifying an environment variable `DGI_MIGRATE_TRACKING_GET_DISABLED=true`.
+
+NOTE: There may be other plugins that access properties from the row by means other than using the `get` plugin, to which the current implementation is blind, for example, `dgi_migrate.process.entity_query`, via its `conditions` key.
 
 ## Troubleshooting/Issues
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,10 @@ Migrations can update existing entities (even without the `--update` flag), shou
 
 To permit partial sources to be provided, we have implemented a process to try to track which destination properties did not have a corresponding source property, by implementing some handling around the `get` plugin. Where there is no source properties for an existing entity, existing values should be left intact. If a source property is provided with an empty value, the existing value should be erased.
 
-This functionality is enabled by default; however, it might be disabled by specifying an environment variable `DGI_MIGRATE_TRACKING_GET_DISABLED=true`.
+This functionality is enabled by default; however:
+
+* it only affects migrations making use of our `dgi_revisioned_entity` destination plugin
+* it might be disabled by specifying an environment variable `DGI_MIGRATE_TRACKING_GET_DISABLED=true`.
 
 NOTE: There may be other plugins that access properties from the row by means other than using the `get` plugin, to which the current implementation is blind, for example, `dgi_migrate.process.entity_query`, via its `conditions` key.
 

--- a/dgi_migrate.module
+++ b/dgi_migrate.module
@@ -34,12 +34,14 @@ function dgi_migrate_migrate_process_info_alter(&$definitions) {
   $lookup['class'] = LockingMigrationLookup::class;
   $lookup['provider'] = 'dgi_migrate';
 
-  $definitions['dgi_migrate_original_get'] = [
-    'provider' => 'dgi_migrate',
-    'id' => 'dgi_migrate_original_get',
-  ] + $definitions['get'];
+  if (getenv('DGI_MIGRATE_TRACKING_GET_DISABLED') !== 'true') {
+    $definitions['dgi_migrate_original_get'] = [
+      'provider' => 'dgi_migrate',
+      'id' => 'dgi_migrate_original_get',
+    ] + $definitions['get'];
 
-  $get =& $definitions['get'];
-  $get['class'] = TrackingGet::class;
-  $get['provider'] = 'dgi_migrate';
+    $get =& $definitions['get'];
+    $get['class'] = TrackingGet::class;
+    $get['provider'] = 'dgi_migrate';
+  }
 }

--- a/dgi_migrate.module
+++ b/dgi_migrate.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\dgi_migrate\Plugin\migrate\process\LockingMigrationLookup;
+use Drupal\dgi_migrate\Plugin\migrate\process\TrackingGet;
 
 /**
  * Implements hook_migration_plugins_alter().
@@ -32,4 +33,13 @@ function dgi_migrate_migrate_process_info_alter(&$definitions) {
   $lookup =& $definitions['migration_lookup'];
   $lookup['class'] = LockingMigrationLookup::class;
   $lookup['provider'] = 'dgi_migrate';
+
+  $definitions['dgi_migrate_original_get'] = [
+    'provider' => 'dgi_migrate',
+    'id' => 'dgi_migrate_original_get',
+  ] + $definitions['get'];
+
+  $get =& $definitions['get'];
+  $get['class'] = TrackingGet::class;
+  $get['provider'] = 'dgi_migrate';
 }

--- a/src/Plugin/migrate/destination/DgiRevisionedEntity.php
+++ b/src/Plugin/migrate/destination/DgiRevisionedEntity.php
@@ -3,6 +3,7 @@
 namespace Drupal\dgi_migrate\Plugin\migrate\destination;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\dgi_migrate\Plugin\migrate\process\TrackingGet;
 use Drupal\migrate\MigrateException;
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
@@ -55,6 +56,9 @@ class DgiRevisionedEntity extends EntityContentBase {
    */
   public function import(Row $row, array $old_destination_id_values = []) {
     $this->rollbackAction = MigrateIdMapInterface::ROLLBACK_DELETE;
+
+    $row = TrackingGet::filterRow($row);
+
     $entity = $this->getEntity($row, $old_destination_id_values);
 
     if (!$entity) {

--- a/src/Plugin/migrate/destination/DgiRevisionedEntity.php
+++ b/src/Plugin/migrate/destination/DgiRevisionedEntity.php
@@ -3,6 +3,7 @@
 namespace Drupal\dgi_migrate\Plugin\migrate\destination;
 
 use Drupal\Core\Entity\ContentEntityInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\dgi_migrate\Plugin\migrate\process\TrackingGet;
 use Drupal\migrate\MigrateException;
 use Drupal\migrate\Plugin\MigrateIdMapInterface;
@@ -52,10 +53,22 @@ class DgiRevisionedEntity extends EntityContentBase {
   }
 
   /**
-   * {@inheritdoc}
+   * Helper; handle process disabling.
+   *
+   * @param \Drupal\migrate\Row $row
+   *   Get entity for given row.
+   * @param array $old_destination_id_values
+   *   Old destination ID values.
+   *
+   * @return \Drupal\Core\Entity\EntityInterface|null
+   *   The entity; otherwise, NULL.
+   *
+   * @see \Drupal\dgi_migrate\Plugin\migrate\destination\DgiRevisionedEntity::getEntity()
    */
-  public function import(Row $row, array $old_destination_id_values = []) {
-    $this->rollbackAction = MigrateIdMapInterface::ROLLBACK_DELETE;
+  private function doGetEntity(Row $row, array $old_destination_id_values = []) : ?EntityInterface {
+    if (getenv('DGI_MIGRATE_TRACKING_GET_DISABLED') === 'true') {
+      return $this->getEntity($row, $old_destination_id_values);
+    }
 
     $filtered_row = TrackingGet::filterRow($row);
 
@@ -68,6 +81,17 @@ class DgiRevisionedEntity extends EntityContentBase {
       $row->setDestinationProperty($property, $values);
     }
     $row->setIdMap($filtered_row->getIdMap());
+
+    return $entity;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function import(Row $row, array $old_destination_id_values = []) {
+    $this->rollbackAction = MigrateIdMapInterface::ROLLBACK_DELETE;
+
+    $entity = $this->doGetEntity($row, $old_destination_id_values);
 
     if (!$entity) {
       throw new MigrateException('Unable to get entity');

--- a/src/Plugin/migrate/destination/DgiRevisionedEntity.php
+++ b/src/Plugin/migrate/destination/DgiRevisionedEntity.php
@@ -57,9 +57,17 @@ class DgiRevisionedEntity extends EntityContentBase {
   public function import(Row $row, array $old_destination_id_values = []) {
     $this->rollbackAction = MigrateIdMapInterface::ROLLBACK_DELETE;
 
-    $row = TrackingGet::filterRow($row);
+    $filtered_row = TrackingGet::filterRow($row);
 
-    $entity = $this->getEntity($row, $old_destination_id_values);
+    $entity = $this->getEntity($filtered_row, $old_destination_id_values);
+
+    foreach ($row->getRawDestination() as $property => $values) {
+      $row->removeDestinationProperty($property);
+    }
+    foreach ($filtered_row->getRawDestination() as $property => $values) {
+      $row->setDestinationProperty($property, $values);
+    }
+    $row->setIdMap($filtered_row->getIdMap());
 
     if (!$entity) {
       throw new MigrateException('Unable to get entity');

--- a/src/Plugin/migrate/destination/DgiRevisionedEntity.php
+++ b/src/Plugin/migrate/destination/DgiRevisionedEntity.php
@@ -48,7 +48,7 @@ class DgiRevisionedEntity extends EntityContentBase {
     $entity_type = $configuration['entity_type'] ?? 'node';
     $instance = parent::create($container, $configuration, 'entity:' . $entity_type, $plugin_definition, $migration);
     $instance->entityType = $entity_type;
-    $instance->migrationId = $migration->id();
+    $instance->migrationId = $migration?->id() ?? '(unknown; not provided)';
     return $instance;
   }
 

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -42,7 +42,6 @@ class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, 
     /** @var \Drupal\migrate\Plugin\MigratePluginManagerInterface $process_plugin_manager */
     $process_plugin_manager = $container->get('plugin.manager.migrate.process');
     $instance->originalPlugin = $process_plugin_manager->createInstance('dgi_migrate_original_get', $configuration, $migration);
-    $instance->migration = $migration;
 
     return $instance;
   }

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -23,7 +23,7 @@ class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, 
   /**
    * The name of the destination property in which to build our tracking info.
    */
-  const PROPERTY_NAME = __CLASS__ . '_tracker';
+  const PROPERTY_NAME = '_dgi_migrate_tracking_get_tracker';
 
   /**
    * Instance of the plugin we are overriding.

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -4,7 +4,6 @@ namespace Drupal\dgi_migrate\Plugin\migrate\process;
 
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\migrate\MigrateExecutableInterface;
-use Drupal\migrate\Plugin\MigratePluginManagerInterface;
 use Drupal\migrate\Plugin\MigrateProcessInterface;
 use Drupal\migrate\Plugin\MigrationInterface;
 use Drupal\migrate\ProcessPluginBase;
@@ -23,6 +22,11 @@ class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, 
 
   const PROPERTY_NAME = __CLASS__ . '_tracker';
 
+  /**
+   * Instance of the plugin we are overriding.
+   *
+   * @var \Drupal\migrate\Plugin\MigrateProcessInterface
+   */
   protected MigrateProcessInterface $originalPlugin;
 
   /**

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -87,7 +87,7 @@ class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, 
       }
       return $is_source ?
         $row->hasSourceProperty($property) :
-        $tracker[$property];
+        ($tracker[$property] ?? $row->hasDestinationProperty($property));
     });
     $row->setDestinationProperty(static::PROPERTY_NAME, $tracker);
 

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -140,6 +140,7 @@ class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, 
     $tracker = $row->getDestinationProperty(static::PROPERTY_NAME);
 
     $copy = $row->cloneWithoutDestination();
+    $copy->setIdMap($row->getIdMap());
     foreach ($row->getRawDestination() as $property => $value) {
       $copy->setDestinationProperty($property, $value);
     }

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Drupal\dgi_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigratePluginManagerInterface;
+use Drupal\migrate\Plugin\MigrateProcessInterface;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Track where things came from.
+ *
+ * Effective looking to augment the core `get` plugin to track what destination
+ * properties had source properties.
+ *
+ * @see \Drupal\migrate\Plugin\migrate\process\Get
+ */
+class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, ContainerFactoryPluginInterface {
+
+  const PROPERTY_NAME = __CLASS__ . '_tracker';
+
+  protected MigrateProcessInterface $originalPlugin;
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, ?MigrationInterface $migration = NULL) : self {
+    $instance = new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+    );
+
+    /** @var \Drupal\migrate\Plugin\MigratePluginManagerInterface $process_plugin_manager */
+    $process_plugin_manager = $container->get('plugin.manager.migrate.process');
+    $instance->originalPlugin = $process_plugin_manager->createInstance('dgi_migrate_original_get', $configuration, $migration);
+    $instance->migration = $migration;
+
+    return $instance;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $tracker = $row->hasDestinationProperty(static::PROPERTY_NAME) ?
+      $row->getDestinationProperty(static::PROPERTY_NAME) :
+      [];
+
+    $source = $this->configuration['source'];
+    $properties = is_string($source) ? [$source] : $source;
+
+    $tracker[$destination_property] = array_any($properties, function (string $property) use ($row, $tracker) {
+      // Adapted from the Row class.
+      // @see https://git.drupalcode.org/project/drupal/-/blob/4f22ed87387ed92e5b1c8be1814de354706f6623/core/modules/migrate/src/Row.php#L345-355
+      $is_source = TRUE;
+      if (str_starts_with($property, '@')) {
+        $property = preg_replace_callback('/^(@?)((?:@@)*)([^@]|$)/', function ($matches) use (&$is_source) {
+          // If there are an odd number of @ in the beginning, it's a
+          // destination.
+          $is_source = empty($matches[1]);
+          // Remove the possible escaping and do not lose the terminating
+          // non-@ either.
+          return str_replace('@@', '@', $matches[2]) . $matches[3];
+        }, $property);
+      }
+      return $is_source ?
+        $row->hasSourceProperty($property) :
+        $tracker[$property];
+    });
+    $row->setDestinationProperty(static::PROPERTY_NAME, $tracker);
+
+    return $this->originalPlugin->transform($value, $migrate_executable, $row, $destination_property);
+  }
+
+  /**
+   * Produce a filtered copy of the row, filtered according to the tracked data.
+   *
+   * @param \Drupal\migrate\Row $row
+   *   The row to filter.
+   *
+   * @return \Drupal\migrate\Row
+   *   The filtered row.
+   */
+  public static function filterRow(Row $row) : Row {
+    if (!$row->hasDestinationProperty(static::PROPERTY_NAME)) {
+      // No tracker; do not do anything.
+      return $row;
+    }
+
+    $tracker = $row->getDestinationProperty(static::PROPERTY_NAME);
+
+    $copy = $row->cloneWithoutDestination();
+    foreach ($row->getRawDestination() as $property => $value) {
+      $copy->setDestinationProperty($property, $value);
+    }
+    // If a source column was present, mark absent properties accordingly.
+    foreach (array_keys(array_filter($tracker)) as $property) {
+      if (!$copy->hasDestinationProperty($property)) {
+        $copy->setEmptyDestinationProperty($property);
+      }
+    }
+    return $copy;
+  }
+
+}

--- a/src/Plugin/migrate/process/TrackingGet.php
+++ b/src/Plugin/migrate/process/TrackingGet.php
@@ -104,6 +104,10 @@ class TrackingGet extends ProcessPluginBase implements MigrateProcessInterface, 
         $copy->setEmptyDestinationProperty($property);
       }
     }
+
+    // Remove our tracking info from the row, as it has served its purpose.
+    $copy->removeDestinationProperty(static::PROPERTY_NAME);
+
     return $copy;
   }
 

--- a/tests/src/Unit/TrackingGetTest.php
+++ b/tests/src/Unit/TrackingGetTest.php
@@ -18,7 +18,7 @@ class TrackingGetTest extends UnitTestCase {
   /**
    * Mock migration executable.
    *
-   * @var \Drupal\migrate\MigrateExecutableInterface|(\Drupal\migrate\MigrateExecutableInterface&\object&\PHPUnit\Framework\MockObject\Stub)|(\Drupal\migrate\MigrateExecutableInterface&\PHPUnit\Framework\MockObject\Stub)|(\object&\PHPUnit\Framework\MockObject\Stub)|\PHPUnit\Framework\MockObject\Stub
+   * @var \Drupal\migrate\MigrateExecutableInterface
    */
   protected MigrateExecutableInterface $mockExecutable;
 

--- a/tests/src/Unit/TrackingGetTest.php
+++ b/tests/src/Unit/TrackingGetTest.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Drupal\Tests\dgi_migrate\Unit;
+
+use Drupal\dgi_migrate\Plugin\migrate\process\TrackingGet;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Plugin\MigrateProcessInterface;
+use Drupal\migrate\Row;
+use Drupal\Tests\UnitTestCase;
+
+/**
+ * Test our TrackingGet class.
+ *
+ * @group dgi_migrate
+ */
+class TrackingGetTest extends UnitTestCase {
+
+  /**
+   * Mock migration executable.
+   *
+   * @var \Drupal\migrate\MigrateExecutableInterface|(\Drupal\migrate\MigrateExecutableInterface&\object&\PHPUnit\Framework\MockObject\Stub)|(\Drupal\migrate\MigrateExecutableInterface&\PHPUnit\Framework\MockObject\Stub)|(\object&\PHPUnit\Framework\MockObject\Stub)|\PHPUnit\Framework\MockObject\Stub
+   */
+  protected MigrateExecutableInterface $mockExecutable;
+
+  /**
+   * A randomly-generated property name for use in the given test.
+   *
+   * @var string
+   */
+  protected string $testPropName;
+
+  /**
+   * {@inheritDoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    $this->mockExecutable = $this->createStub(MigrateExecutableInterface::class);
+    $this->testPropName = $this->randomMachineName();
+  }
+
+  /**
+   * Helper; build out the plugin instance.
+   *
+   * @param array $configuration
+   *   Param to use during instantiation.
+   *
+   * @return \Drupal\dgi_migrate\Plugin\migrate\process\TrackingGet
+   *   The plugin instance.
+   */
+  protected function getInstance(array $configuration) : TrackingGet {
+    return (new TrackingGet($configuration, '', []))
+      ->setWrappedPlugin($this->createStub(MigrateProcessInterface::class));
+  }
+
+  /**
+   * Test the presence of a source property is reflected.
+   */
+  public function testPresentSource() : void {
+    $row = (new Row(
+      [
+        'a' => 'a',
+        'b' => 'b',
+      ],
+      ['a' => 'a'],
+    ))
+      ->freezeSource();
+
+    $this->getInstance(['source' => 'b'])
+      ->transform(NULL, $this->mockExecutable, $row, $this->testPropName);
+    $row->setDestinationProperty($this->testPropName, 'b');
+    $this->assertTrue($row->hasDestinationProperty(TrackingGet::PROPERTY_NAME));
+    $this->assertTrue($row->getDestinationProperty(TrackingGet::PROPERTY_NAME)[$this->testPropName]);
+
+    $filtered = TrackingGet::filterRow($row);
+    $this->assertNotContains($this->testPropName, $filtered->getEmptyDestinationProperties());
+  }
+
+  /**
+   * Test the presence of a source property that does "skip process".
+   */
+  public function testPresentEmptySourceSkip() : void {
+    $row = (new Row(
+      [
+        'a' => 'a',
+        'b' => '',
+      ],
+      ['a' => 'a'],
+    ))
+      ->freezeSource();
+
+    $this->getInstance(['source' => 'b'])
+      ->transform(NULL, $this->mockExecutable, $row, $this->testPropName);
+    $row->setEmptyDestinationProperty($this->testPropName);
+    $this->assertTrue($row->hasDestinationProperty(TrackingGet::PROPERTY_NAME));
+    $this->assertTrue($row->getDestinationProperty(TrackingGet::PROPERTY_NAME)[$this->testPropName]);
+
+    $filtered = TrackingGet::filterRow($row);
+    $this->assertContains($this->testPropName, $filtered->getEmptyDestinationProperties());
+  }
+
+  /**
+   * Test the presence of a source property that gets passed-through.
+   */
+  public function testPresentEmptySourcePass() : void {
+    $row = (new Row(
+      [
+        'a' => 'a',
+        'b' => '',
+      ],
+      ['a' => 'a'],
+    ))
+      ->freezeSource();
+
+    $this->getInstance(['source' => 'b'])
+      ->transform(NULL, $this->mockExecutable, $row, $this->testPropName);
+    $row->setDestinationProperty($this->testPropName, '');
+    $this->assertTrue($row->hasDestinationProperty(TrackingGet::PROPERTY_NAME));
+    $this->assertTrue($row->getDestinationProperty(TrackingGet::PROPERTY_NAME)[$this->testPropName]);
+
+    $filtered = TrackingGet::filterRow($row);
+    $this->assertEquals('', $filtered->getDestinationProperty($this->testPropName));
+    $this->assertNotContains($this->testPropName, $filtered->getEmptyDestinationProperties());
+  }
+
+  /**
+   * Test the absence of a source property is reflected.
+   */
+  public function testAbsentSource() : void {
+    $row = (new Row(
+      ['a' => 'a'],
+      ['a' => 'a'],
+    ))
+      ->freezeSource();
+
+    $this->getInstance(['source' => 'b'])
+      ->transform(NULL, $this->mockExecutable, $row, $this->testPropName);
+    // Approximate behavior MigrateExecutable.
+    // @see https://git.drupalcode.org/project/drupal/-/blob/10.5.x/core/modules/migrate/src/MigrateExecutable.php?ref_type=heads#L476
+    $row->setEmptyDestinationProperty($this->testPropName);
+    $this->assertTrue($row->hasDestinationProperty(TrackingGet::PROPERTY_NAME));
+    $this->assertFalse($row->getDestinationProperty(TrackingGet::PROPERTY_NAME)[$this->testPropName]);
+
+    $filtered = TrackingGet::filterRow($row);
+    $this->assertNull($filtered->getDestinationProperty($this->testPropName));
+    $this->assertNotContains($this->testPropName, $filtered->getEmptyDestinationProperties());
+  }
+
+  /**
+   * Test transitive property existence.
+   */
+  public function testTransitiveExistence() : void {
+    $row = (new Row(
+      [
+        'a' => 'a',
+        'b' => 'b',
+      ],
+      ['a' => 'a'],
+    ))
+      ->freezeSource();
+
+    $transitive_prop = $this->randomMachineName();
+
+    $this->getInstance(['source' => 'b'])
+      ->transform(NULL, $this->mockExecutable, $row, $this->testPropName);
+    $row->setDestinationProperty($this->testPropName, 'b');
+    $this->getInstance(['source' => "@{$this->testPropName}"])
+      ->transform(NULL, $this->mockExecutable, $row, $transitive_prop);
+    $row->setDestinationProperty($transitive_prop, 'b');
+    $this->assertTrue($row->getDestinationProperty(TrackingGet::PROPERTY_NAME)[$transitive_prop]);
+
+    $filtered = TrackingGet::filterRow($row);
+    $this->assertNotContains($transitive_prop, $filtered->getEmptyDestinationProperties());
+  }
+
+  /**
+   * Test transitive property absence.
+   */
+  public function testTransitiveAbsence() : void {
+    $row = (new Row(
+      ['a' => 'a'],
+      ['a' => 'a'],
+    ))
+      ->freezeSource();
+
+    $transitive_prop = $this->randomMachineName();
+
+    $this->getInstance(['source' => 'b'])
+      ->transform(NULL, $this->mockExecutable, $row, $this->testPropName);
+    // Approximate behavior MigrateExecutable.
+    // @see https://git.drupalcode.org/project/drupal/-/blob/10.5.x/core/modules/migrate/src/MigrateExecutable.php?ref_type=heads#L476
+    $row->setEmptyDestinationProperty($this->testPropName);
+    $this->getInstance(['source' => "@{$this->testPropName}"])
+      ->transform(NULL, $this->mockExecutable, $row, $transitive_prop);
+    $row->setEmptyDestinationProperty($transitive_prop);
+    $this->assertFalse($row->getDestinationProperty(TrackingGet::PROPERTY_NAME)[$transitive_prop]);
+
+    $filtered = TrackingGet::filterRow($row);
+    $this->assertNull($filtered->getDestinationProperty($transitive_prop));
+    $this->assertNotContains($transitive_prop, $filtered->getEmptyDestinationProperties());
+  }
+
+}


### PR DESCRIPTION
When performing a migration with rows that update existing entities, leaving properties out of the source for could lead to having the corresponding destination fields on entities cleared of their values.

Let's more directly track the properties based on whether they might have had a value available, such that:
- if a property is absent, we should avoid changing the destination field
- if a property is present, but with an empty/null value, we will clear the destination field
- if a property is present, we will migrate it

More specifically, this should be useful in processes such as `islandora_spreadsheet_ingest`, should a sheet bearing a subset of the fields be provided while also mapping entity IDs (such that it's possible to try to "update" existing entities in the first place).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for Search API direct/immediate indexing and a detailed entity update process, including partial-source handling and tracking configuration via environment flags.

* **New Features**
  * Optional tracking of which source properties populated each destination property during migrations to avoid overwriting existing destination fields.
  * Standardized revision messages to include migration context.

* **Tests**
  * Added unit tests covering tracking behavior across migration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->