### PR TITLE
Adding version check for `checkStatus()` parent function.

### DIFF
--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -478,7 +478,10 @@ class MigrateBatchExecutable extends MigrateExecutable {
    * {@inheritdoc}
    */
   protected function checkStatus() {
-    $status = parent::checkStatus();
+    $status = version_compare(\Drupal::VERSION, '11.3.0', '>=') ?
+      MigrationInterface::RESULT_COMPLETED :
+      parent::checkStatus();
+
 
     if ($status === MigrationInterface::RESULT_COMPLETED) {
       if (!static::isCli() && !static::hasTime()) {


### PR DESCRIPTION
Adam investigated and found that the `checkStatus()` has been removed from the core `MigrateExecutable`, as well as the accompanying memory checks:
- https://git.drupalcode.org/project/drupal/-/commit/7fa679cb3ba002435666825777d7045a51a5ba14

We're doing a version check to see if it's reasonable to run the `checkStatus()` command, otherwise we're setting the status ourselves.

