### PR TITLE
SEC-2930: add trigram indexes for paragraphs parent lookups on PostgreSQL

### DIFF
--- a/dgi_migrate.install
+++ b/dgi_migrate.install
@@ -6,6 +6,7 @@
  */
 
 use Discoverygarden\UpdateHelper;
+use Drupal\Core\Utility\UpdateException;
 
 /**
  * Delete example migration entities migrated to live as plugins.
@@ -40,4 +41,43 @@ function dgi_migrate_update_10001() {
   \Drupal::configFactory()->getEditable('dgi_migrate.settings')
     ->set('suppress_direct_indexing_during_migrations', TRUE)
     ->save();
+}
+
+/**
+ * Add trigram indexes for paragraphs parent lookups on PostgreSQL.
+ *
+ * Drupal's pgsql driver compiles entity-query string conditions to
+ * "column::text ILIKE ...", which btree indexes cannot serve. Deleting nodes
+ * with paragraph fields (e.g. dgi_migrate rollbacks) therefore triggers a
+ * sequential scan of the paragraphs field-data tables for every deleted
+ * node, per paragraph field. GIN trigram indexes on parent_id make those
+ * lookups indexable; observed to reduce large migration rollbacks from
+ * hours to minutes.
+ */
+function dgi_migrate_update_10002() {
+  $database = \Drupal::database();
+  if ($database->databaseType() !== 'pgsql') {
+    return t('Not PostgreSQL; nothing to do.');
+  }
+
+  $has_trgm = $database->query("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'")->fetchField();
+  if (!$has_trgm) {
+    throw new UpdateException('The pg_trgm extension is not installed; run "CREATE EXTENSION pg_trgm;" as a superuser and re-run updates.');
+  }
+
+  $schema = $database->schema();
+  $tables = [
+    'paragraphs_item_field_data' => 'pifd_parent_id_trgm_idx',
+    'paragraphs_item_revision_field_data' => 'pirfd_parent_id_trgm_idx',
+  ];
+  $created = [];
+  foreach ($tables as $table => $index) {
+    if (!$schema->tableExists($table)) {
+      continue;
+    }
+    $database->query("CREATE INDEX IF NOT EXISTS {$index} ON {{$table}} USING gin (parent_id gin_trgm_ops)");
+    $created[] = $index;
+  }
+
+  return t('Created (or verified) indexes: @indexes', ['@indexes' => implode(', ', $created) ?: 'none (paragraphs tables absent)']);
 }


### PR DESCRIPTION
## What / why

Adds `dgi_migrate_update_10002()`, which creates GIN trigram indexes on `parent_id` for the paragraphs field-data tables on PostgreSQL.

### The problem

Drupal's pgsql driver compiles entity-query string conditions to `column::text ILIKE ...`; btree indexes can't serve those, so deleting any node with paragraph fields seq-scans `paragraphs_item_revision_field_data` once per paragraph field per node. dgi_migrate rollbacks are the acute case: a 4,833-node group rollback on uo-prod took ~4 hours, ~95% of it in these scans (EXPLAIN confirmed a parallel seq scan over 488k rows).

### Fleet-wide relevance

Survey (2026-07-14) of `paragraphs_item_revision_field_data` row counts on prod sites: ui-prod 3.5M, nmu-prod 2.4M, jll-prod 2.0M, unr-prod 601k, uo-prod 498k, nmhm-prod 480k, unco-prod 300k, aip-prod 278k, others smaller. The fix is relevant fleet-wide, and rollbacks on the largest sites would otherwise be intractable.

### The update hook

- pgsql-only (no-op elsewhere).
- Throws `UpdateException` if `pg_trgm` is absent (it's installed on the DGI fleet; same extension the `path_alias` trigram index uses).
- `CREATE INDEX IF NOT EXISTS` (idempotent).
- Covers both `paragraphs_item_field_data` and `paragraphs_item_revision_field_data`; skips sites without paragraphs tables.

### Why dgi_migrate as the home

The underlying issue affects any bulk node delete, not only migrations, but dgi_migrate is deployed across the affected fleet, owns the rollback workload where the pain is acute, and already carries similar operational update hooks (e.g. 10001). Open to relocating if maintainers prefer a different module.

### Note on `CONCURRENTLY`

Plain `CREATE INDEX` (not `CONCURRENTLY`) is used because update hooks run at deploy time; the build takes seconds-to-minutes even on the largest tables. Ops can pre-create the index `CONCURRENTLY` on very hot sites before deploying, and the hook will no-op via `IF NOT EXISTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a database update that improves search performance for relevant paragraph data on PostgreSQL installations.
  * Automatically verifies the required PostgreSQL extension and creates appropriate indexes when applicable.

* **Bug Fixes**
  * Provides a clear update error when the required PostgreSQL extension is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->