### PR TITLE
UO-123 / SEC-2940: Retry failing http(s) transfers, and cycle migration batches on memory.

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -18,7 +18,7 @@ jobs:
           },
           "drupal/migrate_directory": {
             "Custom iterator for memory optimization": "https://www.drupal.org/files/issues/2023-03-03/3344946-iterator.patch",
-            "D10 support": "https://www.drupal.org/files/issues/2022-06-16/migrate_directory.2.0.0.rector.patch"
+            "D11 support": "https://git.drupalcode.org/project/migrate_directory/-/commit/d44ecb000f6073caf7cfa91d0abc4c611a16f4da.diff"
           }
         }
       lenient-packages: >-

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,14 +11,12 @@ jobs:
     uses: discoverygarden/phpunit-action/.github/workflows/phpunit.yml@v1
     secrets: inherit
     with:
+      composer_package_prerequisites: >-
+        "drupal/migrate_directory:2.x-dev"
       composer_patches: >-
         {
           "drupal/features": {
             "PHP 8.2 dynamic prop": "https://www.drupal.org/files/issues/2023-07-19/3375425-3.patch"
-          },
-          "drupal/migrate_directory": {
-            "Custom iterator for memory optimization": "https://www.drupal.org/files/issues/2023-03-03/3344946-iterator.patch",
-            "D11 support": "https://git.drupalcode.org/project/migrate_directory/-/commit/d44ecb000f6073caf7cfa91d0abc4c611a16f4da.diff"
           }
         }
       lenient-packages: >-

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,7 @@ jobs:
     uses: discoverygarden/phpunit-action/.github/workflows/phpunit.yml@v1
     secrets: inherit
     with:
-      composer_package_prerequisites: >-
+      composer_prereqs: >-
         "drupal/migrate_directory:2.x-dev"
       composer_patches: >-
         {

--- a/modules/dgi_migrate_foxml_standard_mods/tests/src/Unit/RoleMapperTest.php
+++ b/modules/dgi_migrate_foxml_standard_mods/tests/src/Unit/RoleMapperTest.php
@@ -105,7 +105,7 @@ EOXML
   /**
    * Data provider for the test.
    */
-  public function pathProvider() {
+  public static function pathProvider() {
     $base = '/mods:modsCollection/mods:mods/mods:name';
     return [
       ["{$base}[1]", ['relators:cre']],

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\dgi_migrate;
 
+use Drupal\Component\Utility\Bytes;
 use Drupal\Component\Utility\Timer;
 use Drupal\Core\DependencyInjection\DependencySerializationTrait;
 use Drupal\Core\Queue\QueueInterface;
@@ -57,6 +58,35 @@ class MigrateBatchExecutable extends MigrateExecutable {
   protected array $options;
 
   /**
+   * Memory threshold of which to cycle the batch.
+   *
+   * Absorbed responsibility from <D11.3.
+   *
+   * @see https://www.drupal.org/project/drupal/issues/3006750
+   *
+   * @var float
+   */
+  protected $memoryThreshold;
+
+  /**
+   * Detected memory limit.
+   *
+   * Absorbed responsibility from <D11.3.
+   *
+   * @see https://www.drupal.org/project/drupal/issues/3006750
+   *
+   * @var float|int
+   */
+  protected $memoryLimit;
+
+  /**
+   * Allow our memory check to be bypassed.
+   *
+   * @var bool
+   */
+  protected bool $checkMemory = FALSE;
+
+  /**
    * {@inheritdoc}
    */
   public function __construct(MigrationInterface $migration, MigrateMessageInterface $message, array $options = []) {
@@ -76,6 +106,20 @@ class MigrateBatchExecutable extends MigrateExecutable {
       // @see https://github.com/drush-ops/drush/blob/dbdb6733655231687d8ab68cdea6bf9fedbd0562/includes/batch.inc#L291-L298
       // @see https://git.drupalcode.org/project/drupal/-/blob/8.9.x/core/modules/migrate/src/MigrateExecutable.php#L47
       $this->memoryThreshold = 0.65;
+    }
+    if (!isset($this->memoryLimit)) {
+      $this->checkMemory = filter_var(getenv('DGI_MIGRATE_CHECK_MEMORY_THRESHOLD') ?: 'true', FILTER_VALIDATE_BOOLEAN);
+
+      if ($this->checkMemory) {
+        // Record the memory limit in bytes.
+        $limit = trim(ini_get('memory_limit'));
+        if ($limit == '-1') {
+          $this->memoryLimit = PHP_INT_MAX;
+        }
+        else {
+          $this->memoryLimit = Bytes::toNumber($limit);
+        }
+      }
     }
   }
 
@@ -478,9 +522,15 @@ class MigrateBatchExecutable extends MigrateExecutable {
    * {@inheritdoc}
    */
   protected function checkStatus() {
-    $status = version_compare(\Drupal::VERSION, '11.3.0', '>=') ?
-      MigrationInterface::RESULT_COMPLETED :
-      parent::checkStatus();
+    if (version_compare(\Drupal::VERSION, '11.3.0', '<')) {
+      $status = parent::checkStatus();
+    }
+    elseif ($this->checkMemory) {
+      $status = $this->checkMemory() ? MigrationInterface::RESULT_COMPLETED : MigrationInterface::RESULT_INCOMPLETE;
+    }
+    else {
+      $status = MigrationInterface::RESULT_COMPLETED;
+    }
 
     if ($status === MigrationInterface::RESULT_COMPLETED) {
       if (!static::isCli() && !static::hasTime()) {
@@ -488,6 +538,27 @@ class MigrateBatchExecutable extends MigrateExecutable {
       }
     }
     return $status;
+  }
+
+  /**
+   * Check that the process is under the memory threshold.
+   *
+   * @return bool
+   *   TRUE if under the threshold; otherwise, FALSE.
+   */
+  protected function checkMemory() : bool {
+    $usage = memory_get_usage();
+    $pct_usage = $usage / $this->memoryLimit;
+    $to_return = $pct_usage < $this->memoryThreshold;
+    if (!$to_return) {
+      $this->message->display($this->t('Memory usage hit @usage/@limit (@pct of @threshold); cycling process.', [
+        '@usage' => $usage,
+        '@limit' => $this->memoryLimit,
+        '@pct' => $pct_usage,
+        '@threshold' => $this->memoryThreshold,
+      ]));
+    }
+    return $to_return;
   }
 
   /**

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -62,9 +62,8 @@ class MigrateBatchExecutable extends MigrateExecutable {
    *
    * Absorbed responsibility from <D11.3.
    *
-   * @see https://www.drupal.org/project/drupal/issues/3006750
-   *
    * @var float
+   * @see https://www.drupal.org/project/drupal/issues/3006750
    */
   protected $memoryThreshold;
 
@@ -73,9 +72,8 @@ class MigrateBatchExecutable extends MigrateExecutable {
    *
    * Absorbed responsibility from <D11.3.
    *
-   * @see https://www.drupal.org/project/drupal/issues/3006750
-   *
    * @var float|int
+   * @see https://www.drupal.org/project/drupal/issues/3006750
    */
   protected $memoryLimit;
 
@@ -108,7 +106,8 @@ class MigrateBatchExecutable extends MigrateExecutable {
       $this->memoryThreshold = 0.65;
     }
     if (!isset($this->memoryLimit)) {
-      $this->checkMemory = filter_var(getenv('DGI_MIGRATE_CHECK_MEMORY_THRESHOLD') ?: 'true', FILTER_VALIDATE_BOOLEAN);
+      $env_value = getenv('DGI_MIGRATE_CHECK_MEMORY_THRESHOLD');
+      $this->checkMemory = filter_var($env_value !== FALSE ? $env_value : 'true', FILTER_VALIDATE_BOOLEAN);
 
       if ($this->checkMemory) {
         // Record the memory limit in bytes.

--- a/src/MigrateBatchExecutable.php
+++ b/src/MigrateBatchExecutable.php
@@ -105,6 +105,9 @@ class MigrateBatchExecutable extends MigrateExecutable {
       // @see https://git.drupalcode.org/project/drupal/-/blob/8.9.x/core/modules/migrate/src/MigrateExecutable.php#L47
       $this->memoryThreshold = 0.65;
     }
+    elseif (!isset($this->memoryThreshold)) {
+      $this->memoryThreshold = 0.85;
+    }
     if (!isset($this->memoryLimit)) {
       $env_value = getenv('DGI_MIGRATE_CHECK_MEMORY_THRESHOLD');
       $this->checkMemory = filter_var($env_value !== FALSE ? $env_value : 'true', FILTER_VALIDATE_BOOLEAN);

--- a/src/Plugin/migrate/process/NaiveFileCopy.php
+++ b/src/Plugin/migrate/process/NaiveFileCopy.php
@@ -130,7 +130,7 @@ class NaiveFileCopy extends FileCopy implements ContainerFactoryPluginInterface 
     }
 
     $attempt = 0;
-    while (true) {
+    while (TRUE) {
       try {
         return $this->writeFile($source, $destination, $this->configuration['file_exists']);
       }
@@ -141,7 +141,7 @@ class NaiveFileCopy extends FileCopy implements ContainerFactoryPluginInterface 
           throw $e;
         }
 
-        $backoff = 2**$attempt;
+        $backoff = 2 ** $attempt;
         $attempt++;
         if ($attempt > $this->maxAttempts) {
           throw new MigrateException(sprintf('Failed to transfer %s to %s after %d attempts; failing the row.', $source, $destination, $this->maxAttempts), previous: $e);

--- a/src/Plugin/migrate/process/NaiveFileCopy.php
+++ b/src/Plugin/migrate/process/NaiveFileCopy.php
@@ -24,6 +24,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * Extends "file_copy", additionally accepting:
  * - force_stub: Boolean to force the copying when the row being processed
  *   appears to be a stub.
+ * - max_attempts: Integer indicating number of times to attempt retrying
+ *   transfers. Defaults to 5.
  *
  * @MigrateProcessPlugin(
  *   id = "dgi_migrate.naive_file_copy"
@@ -44,6 +46,13 @@ class NaiveFileCopy extends FileCopy implements ContainerFactoryPluginInterface 
    * @var bool
    */
   protected bool $forceStub;
+
+  /**
+   * Integer for the max attempts we should make to transfer.
+   *
+   * @var int
+   */
+  protected int $maxAttempts;
 
   /**
    * Constructor.
@@ -80,6 +89,7 @@ class NaiveFileCopy extends FileCopy implements ContainerFactoryPluginInterface 
     if ($this->configuration['move']) {
       throw new \LogicException("Moving files is not supported with {$this->getPluginId()}.");
     }
+    $this->maxAttempts = $this->configuration['max_attempts'] ?? 5;
   }
 
   /**
@@ -119,7 +129,33 @@ class NaiveFileCopy extends FileCopy implements ContainerFactoryPluginInterface 
       }
     }
 
-    return $this->writeFile($source, $destination, $this->configuration['file_exists']);
+    $attempt = 0;
+    while (true) {
+      try {
+        return $this->writeFile($source, $destination, $this->configuration['file_exists']);
+      }
+      catch (\Exception $e) {
+        if (!(str_starts_with($source, 'https://') || str_starts_with($source, 'http://'))) {
+          // If it does not look like a source that might sporadically fail,
+          // let's not bother retrying.
+          throw $e;
+        }
+
+        $backoff = 2**$attempt;
+        $attempt++;
+        if ($attempt > $this->maxAttempts) {
+          throw new MigrateException(sprintf('Failed to transfer %s to %s after %d attempts; failing the row.', $source, $destination, $this->maxAttempts), previous: $e);
+        }
+        $this->logger->notice('Failed to transfer {source} to {dest}, attempt {attempt}/{max_attempts}; sleeping {backoff} seconds before retrying.', [
+          'source' => $source,
+          'dest' => $destination,
+          'attempt' => $attempt,
+          'max_attempts' => $this->maxAttempts,
+          'backoff' => $backoff,
+        ]);
+        sleep($backoff);
+      }
+    }
   }
 
   /**

--- a/src/Plugin/migrate/process/NaiveFileCopy.php
+++ b/src/Plugin/migrate/process/NaiveFileCopy.php
@@ -146,12 +146,14 @@ class NaiveFileCopy extends FileCopy implements ContainerFactoryPluginInterface 
         if ($attempt > $this->maxAttempts) {
           throw new MigrateException(sprintf('Failed to transfer %s to %s after %d attempts; failing the row.', $source, $destination, $this->maxAttempts), previous: $e);
         }
-        $this->logger->notice('Failed to transfer {source} to {dest}, attempt {attempt}/{max_attempts}; sleeping {backoff} seconds before retrying.', [
+        $this->logger->notice('Failed to transfer {source} to {dest}, attempt {attempt}/{max_attempts}; sleeping {backoff} seconds before retrying. Exception message and trace: {message} {trace}', [
           'source' => $source,
           'dest' => $destination,
           'attempt' => $attempt,
           'max_attempts' => $this->maxAttempts,
           'backoff' => $backoff,
+          'message' => $e->getMessage(),
+          'trace' => $e->getTraceAsString(),
         ]);
         sleep($backoff);
       }


### PR DESCRIPTION
Could be sporadic network issues causing failures, so let's retry.

Also, it seems that there's multiple other static in-memory caches that are not LRU caches, so re-implement the process cycling that was torn out with https://www.drupal.org/project/drupal/issues/3006750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when transferring from HTTP/HTTPS sources by adding retry logic with exponential backoff (configurable, default 5 attempts).
  * Enhanced batch execution to detect when memory usage exceeds a threshold and automatically cycle rather than fail.
* **Tests**
  * Updated a unit test helper to use a static data provider method.
* **Chores**
  * Adjusted the PHPUnit workflow’s composer prerequisites and patch set to match the current setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->